### PR TITLE
Update fusioninventory/inc/unknowndevice.class.php

### DIFF
--- a/fusioninventory/inc/unknowndevice.class.php
+++ b/fusioninventory/inc/unknowndevice.class.php
@@ -832,11 +832,8 @@ class PluginFusioninventoryUnknownDevice extends CommonDBTM {
       if (empty($folder)) {
          $folder = '0';
       }
-      if (!file_exists(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype)) {
-         mkdir(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype);
-      }
       if (!file_exists(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype."/".$folder)) {
-         mkdir(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype."/".$folder);
+         mkdir(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype."/".$folder, 0755, true);
       }
       $fileopen = fopen(GLPI_PLUGIN_DOC_DIR."/".$pluginname."/".$itemtype."/".$folder."/".$items_id, 'w');
       fwrite($fileopen, $xml);


### PR DESCRIPTION
I see, someone reported the problem with this mkdir() already, but it's still broken now.

Here is my variant.

Software versions: GLPI 0.83.31 + FusionInventory 0.83+2.0

Example trace: http://pastebin.com/bEaaWM0P
