### PR TITLE
Double join in printer when adding colums in display preferences

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -1361,10 +1361,8 @@ function plugin_fusioninventory_addLeftJoin($itemtype, $ref_table, $new_table, $
          break;
 
       case 'Printer':
-         $already_link_tables_tmp = $already_link_tables;
-         array_pop($already_link_tables_tmp);
          $leftjoin_fusioninventory_printers = 1;
-         if ((in_array('glpi_plugin_fusioninventory_printers', $already_link_tables_tmp))) {
+         if ((in_array('glpi_plugin_fusioninventory_printers', $already_link_tables))) {
 
             $leftjoin_fusioninventory_printers = 0;
          }


### PR DESCRIPTION
When adding this fields in display preferences of Printer page ( global or personnal) : 

* snmp authentication
* fusinv - last inventory

, we got a sql error : 
/* Erreur SQL (1066): Not unique table/alias: 'glpi_plugin_fusioninventory_printers' */

The commit attached fixes this issue.
However, I can't understand the reason of presence of array_pop on already_linked_tables var.
Maybe an old code from previous glpi version.

Also, I could fix this issue by using join_param on the searchoption (with before_join) and remove the corresponding hooks.
Did you have a constraint to declare these joins (all) in plugin_fusioninventory_addLeftJoin function (hook.php) ?

Rgds.