### PR TITLE
fix fatal error on networkinventory

### DIFF
--- a/inc/inventorynetworkequipmentlib.class.php
+++ b/inc/inventorynetworkequipmentlib.class.php
@@ -323,7 +323,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends CommonDBTM {
                        "`itemtype`='NetworkEquipment'
                           AND `items_id`='".$items_id."'
                           AND `logical_number` = '".$a_port['logical_number']."'", '', 1));
-            if (count($a_ports_DB) > 0) {
+            if ($a_ports_DB !== false && count($a_ports_DB) > 0) {
                $networkPort->delete($a_ports_DB);
             }
          }


### PR DESCRIPTION
On netinventory for each scanned equipement we have this in php_error.log

````
2015-09-18 14:02:53 [351@adelaunay-ThinkPad-Edge-E320]
  *** PHP Catchable Fatal Error(4096): Argument 1 passed to CommonDBTM::delete() must be of the type array, boolean given, called in /media/adelaunay/f8300cb9-ce6d-419c-bd74-5040e0102657/www/glpi/0.90-git/plugins/fusioninventory/inc/inventorynetworkequipmentlib.class.php on line 329 and defined
  Backtrace :
  inc/commondbtm.class.php:1283                      
  .../inc/inventorynetworkequipmentlib.class.php:329 CommonDBTM->delete()
  .../inc/inventorynetworkequipmentlib.class.php:130 PluginFusioninventoryInventoryNetworkEquipmentLib->importPorts()
  ...inc/communicationnetworkinventory.class.php:291 PluginFusioninventoryInventoryNetworkEquipmentLib->updateNetworkEquipment()
  ...inc/communicationnetworkinventory.class.php:518 PluginFusioninventoryCommunicationNetworkInventory->importDevice()
  ...inventory/inc/inventoryruleimport.class.php:721 PluginFusioninventoryCommunicationNetworkInventory->rulepassed()
  inc/rule.class.php:1406                            PluginFusioninventoryInventoryRuleImport->executeActions()
  inc/rulecollection.class.php:1459                  Rule->process()
  ...inc/communicationnetworkinventory.class.php:367 RuleCollection->processAllRules()
  ...inc/communicationnetworkinventory.class.php:189 PluginFusioninventoryCommunicationNetworkInventory->sendCriteria()
  ...inc/communicationnetworkinventory.class.php:106 PluginFusioninventoryCommunicationNetworkInventory->importContent()
  ...fusioninventory/inc/communication.class.php:222 PluginFusioninventoryCommunicationNetworkInventory->import()
  ...fusioninventory/inc/communication.class.php:452 PluginFusioninventoryCommunication->import()
  plugins/fusioninventory/front/communication.php:88 PluginFusioninventoryCommunication->handleOCSCommunication()
  plugins/fusioninventory/index.php:51               include_once()
````