### PR TITLE
retrieve inventory data in case of delete last lock on a item

### DIFF
--- a/inc/lock.class.php
+++ b/inc/lock.class.php
@@ -749,6 +749,12 @@ class PluginFusioninventoryLock extends CommonDBTM{
             }
          }
       }
+
+      //delete all lock case (no more lock)
+      if (!isset($item->updates)) {
+         $a_fieldList = array();
+      }
+
       $item_device = new $itemtype();
       $item_device->getFromDB($items_id);
       $a_serialized = $pfLock->getSerializedInventoryArray($itemtype, $items_id);


### PR DESCRIPTION
This impacts the retrieval of inventory data when deleting locks.

If after deletion of a lock, another locks are still present, it works as intended (update case)
But in case of deletion of all lock (or last lock), deletion is ok but retrieval of data not triggered (delete case).

This fix, check the presence of item->update in deletelock function to detect if a CommonDBTM::delete or update function is triggered.
