### PR TITLE
Add is_dynamic=1 when importing a monitor or a peripheral

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -859,6 +859,7 @@ class PluginFusioninventoryFormatconvert {
                                               'MANUFACTURER' => 'manufacturers_id',
                                               'SERIAL'       => 'serial',
                                               'DESCRIPTION'  => 'comment'));
+            $array_tmp['is_dynamic'] = 1;
             if (!isset($array_tmp['name'])) {
                $array_tmp['name'] = '';
             }
@@ -933,6 +934,7 @@ class PluginFusioninventoryFormatconvert {
                                               'SERIAL'       => 'serial',
                                               'PRODUCTNAME'  => 'productname'));
 
+            $array_tmp['is_dynamic'] = 1;
             if(isset($a_peripherals['VENDORID'])
                      AND $a_peripherals['VENDORID'] != ''
                      AND isset($a_peripherals['PRODUCTID'])) {


### PR DESCRIPTION
When importing a monitor or a peripheral, is_dynamic field seems not to be set.
This PR sets the field during import