### PR TITLE
Add is_dynamic=1 when importing a monitor or a peripheral or printer

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -859,6 +859,7 @@ class PluginFusioninventoryFormatconvert {
                                               'MANUFACTURER' => 'manufacturers_id',
                                               'SERIAL'       => 'serial',
                                               'DESCRIPTION'  => 'comment'));
+            $array_tmp['is_dynamic'] = 1;
             if (!isset($array_tmp['name'])) {
                $array_tmp['name'] = '';
             }
@@ -893,6 +894,7 @@ class PluginFusioninventoryFormatconvert {
                                               'NAME'         => 'name',
                                               'PORT'         => 'port',
                                               'SERIAL'       => 'serial'));
+            $array_tmp['is_dynamic'] = 1;
             if (strstr($array_tmp['port'], "USB")) {
                $array_tmp['have_usb'] = 1;
             } else {
@@ -933,6 +935,7 @@ class PluginFusioninventoryFormatconvert {
                                               'SERIAL'       => 'serial',
                                               'PRODUCTNAME'  => 'productname'));
 
+            $array_tmp['is_dynamic'] = 1;
             if(isset($a_peripherals['VENDORID'])
                      AND $a_peripherals['VENDORID'] != ''
                      AND isset($a_peripherals['PRODUCTID'])) {

--- a/phpunit/1_Unit/ComputerTransformationTest.php
+++ b/phpunit/1_Unit/ComputerTransformationTest.php
@@ -515,12 +515,14 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
       $a_reference[0] = array(
             'manufacturers_id'   => 'NEC Technologies, Inc.',
             'name'               => 'Écran Plug-and-Play',
-            'serial'             => ''
+            'serial'             => '',
+            'is_dynamic'         => 1
           );
       $a_reference[1] = array(
             'manufacturers_id'   => 'Lenovo',
             'name'               => 'ThinkPad Display 1280x800',
             'serial'             => 'UBYVUTFYEIUI',
+            'is_dynamic'         => 1
           );
       $this->assertEquals($a_reference, $a_return['monitor']);
    }

--- a/phpunit/1_Unit/ComputerUpdateTest.php
+++ b/phpunit/1_Unit/ComputerUpdateTest.php
@@ -191,7 +191,8 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
             Array(
                     'name'              => 'ThinkPad Display 1280x800',
                     'serial'            => 'UBYVUTFYEIUI',
-                    'manufacturers_id'  => 'Lenovo'
+                    'manufacturers_id'  => 'Lenovo',
+                    'is_dynamic'        => 1
                 )
       );
 
@@ -199,7 +200,8 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
             Array(
                     'name'      => 'HP Deskjet 5700 Series',
                     'serial'    => 'MY47L1W1JHEB6',
-                    'have_usb'  => 1
+                    'have_usb'  => 1,
+                    'is_dynamic' => 1
                 )
       );
 
@@ -1012,7 +1014,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
           'groups_id'         => '0',
           'states_id'         => '0',
           'ticket_tco'        => '0.0000',
-          'is_dynamic'        => '0',
+          'is_dynamic'        => '1',
       );
 
       $this->assertEquals($a_reference, $monitor->fields);
@@ -1075,7 +1077,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
           'groups_id'            => '0',
           'states_id'            => '0',
           'ticket_tco'           => '0.0000',
-          'is_dynamic'           => '0',
+          'is_dynamic'           => '1',
       );
 
       $this->assertEquals($a_reference, $printer->fields);

--- a/phpunit/2_Integration/ComputerMonitorTest.php
+++ b/phpunit/2_Integration/ComputerMonitorTest.php
@@ -68,7 +68,8 @@ class ComputerMonitor extends Common_TestCase {
               array(
                   'name'    => 'DELL E1911',
                   'manufacturers_id'=> 2,
-                  'serial'  => 'W6VPJ1840E7B'
+                  'serial'  => 'W6VPJ1840E7B',
+                  'is_dynamic' => 1
               )
           ),
           'printer'        => array(),
@@ -125,7 +126,8 @@ class ComputerMonitor extends Common_TestCase {
               array(
                   'name'    => 'DELL E1911',
                   'manufacturers_id'=> 2,
-                  'serial'  => 'W6VPJ1840E7B'
+                  'serial'  => 'W6VPJ1840E7B',
+                  'is_dynamic' => 1
               )
           ),
           'printer'        => array(),

--- a/phpunit/2_Integration/ComputerPeripheralTest.php
+++ b/phpunit/2_Integration/ComputerPeripheralTest.php
@@ -184,7 +184,7 @@ class ComputerPeripheral extends RestoreDatabase_TestCase {
               'is_global'           => '0',
               'is_deleted'          => '0',
               'is_template'         => '0',
-              'is_dynamic'          => '0'
+              'is_dynamic'          => '1'
           ),
           2 => array(
               'name' => 'H5321 gw Mobile Broadband Device',
@@ -196,7 +196,7 @@ class ComputerPeripheral extends RestoreDatabase_TestCase {
               'is_global'           => '0',
               'is_deleted'          => '0',
               'is_template'         => '0',
-              'is_dynamic'          => '0'
+              'is_dynamic'          => '1'
           ),
           3 => array(
               'name' => 'Périphérique d’entrée USB',
@@ -208,7 +208,7 @@ class ComputerPeripheral extends RestoreDatabase_TestCase {
               'is_global'           => '0',
               'is_deleted'          => '0',
               'is_template'         => '0',
-              'is_dynamic'          => '0'
+              'is_dynamic'          => '1'
           )
       );
 

--- a/phpunit/2_Integration/ComputerPrinterTest.php
+++ b/phpunit/2_Integration/ComputerPrinterTest.php
@@ -67,12 +67,14 @@ class ComputerPrinter extends Common_TestCase {
               array(
                   'name'    => 'p1',
                   'have_usb'=> 0,
-                  'serial'  => ''
+                  'serial'  => '',
+                  'is_dynamic' => 1
               ),
               array(
                   'name'    => 'p2',
                   'have_usb'=> 0,
-                  'serial'  => 's1537'
+                  'serial'  => 's1537',
+                  'is_dynamic' => 1
               )
           ),
           'peripheral'     => array(),
@@ -130,12 +132,14 @@ class ComputerPrinter extends Common_TestCase {
               array(
                   'name'    => 'p1',
                   'have_usb'=> 0,
-                  'serial'  => 'f275'
+                  'serial'  => 'f275',
+                  'is_dynamic' => 1
               ),
               array(
                   'name'    => 'p2',
                   'have_usb'=> 0,
-                  'serial'  => 's1537'
+                  'serial'  => 's1537',
+                  'is_dynamic' => 1
               )
           ),
           'peripheral'     => array(),
@@ -172,12 +176,14 @@ class ComputerPrinter extends Common_TestCase {
               array(
                   'name'    => 'p1',
                   'have_usb'=> 0,
-                  'serial'  => ''
+                  'serial'  => '',
+                  'is_dynamic' => 1
               ),
               array(
                   'name'    => 'p2',
                   'have_usb'=> 0,
-                  'serial'  => ''
+                  'serial'  => '',
+                  'is_dynamic' => 1
               )
           ),
           'peripheral'     => array(),


### PR DESCRIPTION
Add tests for is_dynamic fix

Fix unit test

Fix is_dynamic printer

FIx phpunit with is_dynamic and printers

Fix unit tests