### PR TITLE
enable import of removable media

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -648,6 +648,17 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       echo "</td>";
       echo "</tr>";
 
+      echo "<tr class='tab_bg_1'>";
+      echo "<td colspan='2'>";
+      echo "</td>";
+      echo "<td>";
+      echo _n('Removable medias', 'Removable medias', 2, "fusioninventory")."&nbsp;:";
+      echo "</td>";
+      echo "<td>";
+      Dropdown::showYesNo("component_removablemedia", $pfConfig->getValue('component_removablemedia'));
+      echo "</td>";
+      echo "</tr>";
+
       $options['candel'] = FALSE;
       $pfConfig->showFormButtons($options);
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -120,6 +120,7 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       $input['component_drive']        = 1;
       $input['component_networkdrive'] = 1;
       $input['component_control']      = 1;
+      $input['component_removablemedia'] = 0;
       $input['states_id_default']      = 0;
       $input['location']               = 0;
       $input['group']                  = 0;

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -886,15 +886,26 @@ class PluginFusioninventoryFormatconvert {
       $a_inventory['computerdisk'] = array();
       if (isset($array['DRIVES'])) {
          foreach ($array['DRIVES'] as $a_drives) {
+            $isNetworkDriveOrFS = false;
+            $iseRemovableMedia = false;
+            if (isset($a_drives['TYPE'])) {
+               switch ($a_drives['TYPE']) {
+                  case 'Network Drive':
+                     $isNetworkDriveOrFS = true;
+                     break;
+
+                  case 'Removable Disk':
+                  case 'Compact Disc':
+                     $iseRemovableMedia = true;
+                     break;
+               }
+            }
+            if (isset($a_drives['FILESYSTEM']) && $a_drives['FILESYSTEM'] == 'nfs') {
+               $isNetworkDriveOrFS = true;
+            }
             if ($pfConfig->getValue("component_drive") == '0'
-                OR ($pfConfig->getValue("component_networkdrive") == '0'
-                    AND ((isset($a_drives['TYPE'])
-                       AND $a_drives['TYPE'] == 'Network Drive')
-                        OR isset($a_drives['FILESYSTEM'])
-                       AND $a_drives['FILESYSTEM'] == 'nfs'))
-                /*OR ((isset($a_drives['TYPE'])) AND
-                    (($a_drives['TYPE'] == "Removable Disk")
-                   OR ($a_drives['TYPE'] == "Compact Disc")))*/) {
+                OR ($pfConfig->getValue("component_networkdrive") == '0' AND $isNetworkDriveOrFS)
+                OR ($pfConfig->getValue("component_removablemedia") == '0' AND $iseRemovableMedia)) {
 
             } else {
                if ($pfConfig->getValue('import_volume') == 1) {

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -887,7 +887,7 @@ class PluginFusioninventoryFormatconvert {
       if (isset($array['DRIVES'])) {
          foreach ($array['DRIVES'] as $a_drives) {
             $isNetworkDriveOrFS = false;
-            $iseRemovableMedia = false;
+            $isRemovableMedia = false;
             if (isset($a_drives['TYPE'])) {
                switch ($a_drives['TYPE']) {
                   case 'Network Drive':
@@ -896,7 +896,7 @@ class PluginFusioninventoryFormatconvert {
 
                   case 'Removable Disk':
                   case 'Compact Disc':
-                     $iseRemovableMedia = true;
+                     $isRemovableMedia = true;
                      break;
                }
             }
@@ -905,7 +905,7 @@ class PluginFusioninventoryFormatconvert {
             }
             if ($pfConfig->getValue("component_drive") == '0'
                 OR ($pfConfig->getValue("component_networkdrive") == '0' AND $isNetworkDriveOrFS)
-                OR ($pfConfig->getValue("component_removablemedia") == '0' AND $iseRemovableMedia)) {
+                OR ($pfConfig->getValue("component_removablemedia") == '0' AND $isRemovableMedia)) {
 
             } else {
                if ($pfConfig->getValue('import_volume') == 1) {

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -892,9 +892,9 @@ class PluginFusioninventoryFormatconvert {
                        AND $a_drives['TYPE'] == 'Network Drive')
                         OR isset($a_drives['FILESYSTEM'])
                        AND $a_drives['FILESYSTEM'] == 'nfs'))
-                OR ((isset($a_drives['TYPE'])) AND
+                /*OR ((isset($a_drives['TYPE'])) AND
                     (($a_drives['TYPE'] == "Removable Disk")
-                   OR ($a_drives['TYPE'] == "Compact Disc")))) {
+                   OR ($a_drives['TYPE'] == "Compact Disc")))*/) {
 
             } else {
                if ($pfConfig->getValue('import_volume') == 1) {

--- a/phpunit/2_Integration/RemovableMediaImportTest.json
+++ b/phpunit/2_Integration/RemovableMediaImportTest.json
@@ -1,0 +1,28 @@
+{ "data" : [
+
+  [{
+    "inventory" : {
+      "CONTENT" : {
+        "HARDWARE" : { "NAME" : "pc1" },
+        "DRIVES" : [
+          {
+            "DESCRIPTION" : "Disque CD-ROM",
+            "LETTER" : "D:",
+            "TYPE" : "Compact Disc"
+          }
+        ],
+        "BIOS" : { "SSN" : "xxyyzz" }
+      },
+      "AGENT" : {
+        "name" : "pc1-2013-02-13",
+        "device_id" : "pc1-2013-02-13"
+      }
+    },
+    "expected_results" : {
+      "nb_drives_when_enabled" : 1,
+      "nb_drives_when_disabled" : 0
+    }
+  }]
+
+]}
+

--- a/phpunit/2_Integration/RemovableMediaImportTest.php
+++ b/phpunit/2_Integration/RemovableMediaImportTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ ------------------------------------------------------------------------
+FusionInventory
+Copyright (C) 2010-2016 by the FusionInventory Development Team.
+
+http://www.fusioninventory.org/   http://forge.fusioninventory.org/
+------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of FusionInventory project.
+
+FusionInventory is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FusionInventory is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with FusionInventory. If not, see <http://www.gnu.org/licenses/>.
+
+------------------------------------------------------------------------
+
+@package   FusionInventory
+@author    David Durieux
+@co-author
+@copyright Copyright (c) 2010-2016 FusionInventory team
+@license   AGPL License 3.0 or (at your option) any later version
+http://www.gnu.org/licenses/agpl-3.0-standalone.html
+@link      http://www.fusioninventory.org/
+@link      http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/
+@since     2013
+
+------------------------------------------------------------------------
+*/
+
+
+class RemovableMediaImportTest extends RestoreDatabase_TestCase {
+   
+   public function disabledDataProvider() {
+   
+      $filename = pathinfo(__FILE__);
+      $json_filename = implode(
+            DIRECTORY_SEPARATOR,
+            array(
+                  $filename['dirname'],
+                  $filename['filename']
+            )
+            ).".json";
+   
+            $jsondata = json_decode(
+                  file_get_contents( $json_filename ),
+                  TRUE
+                  );
+   
+            return $jsondata['data'];
+   }
+   
+   /**
+    * @test
+    * @dataProvider disabledDataProvider
+    */
+   public function importWithRemovableMedia($data) {
+      global $PF_CONFIG;
+      
+      $_SESSION['glpiactive_entity'] = 0;
+      $_SESSION['glpiactiveentities_string'] = 0;
+      $_SESSION['glpishowallentities'] = 1;
+      $_SESSION['glpiname'] = 'glpi';
+      
+      unset($PF_CONFIG['component_removablemedia']);
+      $pfConfig = new PluginFusioninventoryConfig();
+      $pfConfig->updateValue('component_removablemedia', '1');
+      
+      $pfiComputerInv  = new PluginFusioninventoryInventoryComputerInventory();
+      
+      $inventory = array();
+      $inventory['CONTENT'] = $data['inventory']['CONTENT'];
+      
+      // ** Add agent
+      $pfAgent = new PluginFusioninventoryAgent();
+      $agent_name = $data['inventory']['AGENT']['name'];
+      $computer_name = $data['inventory']['CONTENT']['HARDWARE']['NAME'];
+      $agents_id = $pfAgent->add($data['inventory']['AGENT']);
+      $_SESSION['plugin_fusioninventory_agents_id'] = $agents_id;
+      
+      // ** Add
+      $pfiComputerInv->import($data['inventory']['AGENT']['device_id'], "", $inventory); // creation
+      
+      $this->countDrivesWhenEnabled($data);
+   }
+   
+   /**
+    * @test
+    * @dataProvider disabledDataProvider
+    */
+   public function importWithoutRemovableMedia($data) {
+      global $PF_CONFIG;
+      
+      $_SESSION['glpiactive_entity'] = 0;
+      $_SESSION['glpiactiveentities_string'] = 0;
+      $_SESSION['glpishowallentities'] = 1;
+      $_SESSION['glpiname'] = 'glpi';
+
+      unset($PF_CONFIG['component_removablemedia']);
+      $pfConfig = new PluginFusioninventoryConfig();
+      $pfConfig->updateValue('component_removablemedia', '0');
+      
+      
+      $pfiComputerInv  = new PluginFusioninventoryInventoryComputerInventory();
+   
+      $inventory = array();
+      $inventory['CONTENT'] = $data['inventory']['CONTENT'];
+   
+      // ** Add agent
+      $pfAgent = new PluginFusioninventoryAgent();
+      $agent_name = $data['inventory']['AGENT']['name'];
+      $computer_name = $data['inventory']['CONTENT']['HARDWARE']['NAME'];
+      $agents_id = $pfAgent->add($data['inventory']['AGENT']);
+      $_SESSION['plugin_fusioninventory_agents_id'] = $agents_id;
+   
+      // ** Add
+      $pfiComputerInv->import($data['inventory']['AGENT']['device_id'], "", $inventory); // creation
+   
+      $this->countDrivesWhenDisabled($data);
+   }
+   
+   public function countDrivesWhenDisabled($data) {
+      $agent_name = $data['inventory']['AGENT']['name'];
+      $computer_name = $data['inventory']['CONTENT']['HARDWARE']['NAME'];
+      $nb_drives_in_database = countElementsInTable("glpi_computerdisks");
+      $nb_expected_drives = $data['expected_results']['nb_drives_when_disabled'];
+      $this->assertEquals(
+            $nb_expected_drives,
+            $nb_drives_in_database,
+            "The number of drives expected in database doesn't match after importing \n".
+            "inventory of agent ".$agent_name." (Computer ".$computer_name.").\n".
+            "The database counts ".$nb_drives_in_database." versions while there should be \n".
+            $nb_expected_drives."."
+            );
+   
+   }
+    
+   public function countDrivesWhenEnabled($data) {
+      $agent_name = $data['inventory']['AGENT']['name'];
+      $computer_name = $data['inventory']['CONTENT']['HARDWARE']['NAME'];
+      $nb_drives_in_database = countElementsInTable("glpi_computerdisks");
+      $nb_expected_drives = $data['expected_results']['nb_drives_when_enabled'];
+      $this->assertEquals(
+            $nb_expected_drives,
+            $nb_drives_in_database,
+            "The number of drives expected in database doesn't match after importing \n".
+            "inventory of agent ".$agent_name." (Computer ".$computer_name.").\n".
+            "The database counts ".$nb_drives_in_database." versions while there should be \n".
+            $nb_expected_drives."."
+            );
+       
+   }
+    
+}


### PR DESCRIPTION
This patch allow import of removable volumes, previously filtered out.

Code commented out because I think it may be useful to build an admin preference in the plugin's settings panel.
