### PR TITLE
Fix a cycle in the importToken method

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -537,7 +537,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
    function importToken($arrayinventory) {
 
       if (isset($arrayinventory['DEVICEID'])) {
-         $pfAgent = new PluginFusioninventoryAgent();
+         $pfAgent = this;
          $a_agent = $pfAgent->find("`device_id`='".$arrayinventory['DEVICEID']."'", "", "1");
          if (empty($a_agent)) {
             $a_input = array();


### PR DESCRIPTION
I experienced memory leak calling from sccm plugin and it seems to me that this line was creating an useless cycle .... right ?
