### PR TITLE
Add a build parameter to replace hardcoded http host in CollectsTest.php

### DIFF
--- a/phpunit/build.xml
+++ b/phpunit/build.xml
@@ -6,6 +6,7 @@
  >
 
  <property name="fusioninventory.directory" value="${basedir}/glpi/plugins/fusioninventory" />
+ <property name="fusioninventory.http.host" value="localhost:8088" />
 
  <target name="build"
   depends="prepare,lint,phploc,pdepend,phpmd-ci,phpcs-ci,phpcpd,phpdox"/>
@@ -48,6 +49,12 @@
   </exec>
  </target>
 
+ <condition property="hosts.differs">
+  <not>
+   <equals arg1="localhost:8088" arg2="${fusioninventory.http.host}"/>
+  </not>
+ </condition>
+
  <target name="prepare" depends="clean" description="Prepare for build">
   <mkdir dir="${basedir}/build/api"/>
   <mkdir dir="${basedir}/build/code-browser"/>
@@ -55,6 +62,20 @@
   <mkdir dir="${basedir}/build/logs"/>
   <mkdir dir="${basedir}/build/pdepend"/>
   <mkdir dir="${basedir}/build/phpdox"/>
+
+  <available file="${basedir}/glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php.bkp" property="bkpfile.exists" type="file"/>
+  <sequential if:true="${bkpfile.exists}">
+   <move file="./glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php.bkp" tofile="./glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php" failonerror="false"/>
+  </sequential>
+  <sequential if:true="${hosts.differs}">
+   <copy file="./glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php" tofile="./glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php.bkp"/>
+   <replace
+    file="./glpi/plugins/fusioninventory/phpunit/2_Integration/CollectsTest.php"
+    token="localhost:8088"
+    value="${fusioninventory.http.host}"
+    failOnNoReplacements="true"
+   />
+  </sequential>
  </target>
 
  <target name="lint" description="Perform syntax check of sourcecode files">


### PR DESCRIPTION
There is an hardcoded http host and port hard coded in CollectsTest.php file; that prevents unit tests to be run on my local machine.

I've tried to add a parameter at runtime; I do not know if there is another way to go, I do not know much ant nor phpunit, and I'm not sure of the possible interactions between both of them.

Well, that works for me, but maybe there would be a more simple or elegant  solution.