### PR TITLE
Fix wrong links (front\printer_counter.php not found) in printer log …

### DIFF
--- a/front/printerlogreport.php
+++ b/front/printerlogreport.php
@@ -77,7 +77,7 @@ if (!isset($_SESSION['glpi_plugin_fusioninventory_date_end'])) {
 
 displaySearchForm();
 
-$_GET['target']="printer_counter.php";
+$_GET['target']="printerlogreport.php";
 
 Search::show('PluginFusioninventoryPrinterLogReport');
 


### PR DESCRIPTION
…report page. closes #1911