### PR TITLE
Fix call to addinventoryinfos: using doHook to not return correctly t…

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -1524,7 +1524,7 @@ class PluginFusioninventoryFormatconvert {
          'inventory' => $a_inventory,
          'source'    => $array
       );
-      $plugin_values = Plugin::doHook(
+      $plugin_values = Plugin::doHookFunction(
          "fusioninventory_addinventoryinfos",
          $plugin_params
       );

--- a/phpunit/1_Unit/ComputerTransformationTest.php
+++ b/phpunit/1_Unit/ComputerTransformationTest.php
@@ -1047,7 +1047,55 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
       $this->assertEquals($a_reference, $a_return['processor']);
    }
 
+   /**
+    * @test
+    */
+   public function ComputerHook_addinventoryinfos () {
+      global $DB, $PLUGIN_HOOKS;
 
+      $DB->connect();
+
+      $_SESSION["plugin_fusioninventory_entity"] = 0;
+      $_SESSION["glpiname"] = 'Plugin_FusionInventory';
+
+      $a_computer = [
+        'HARDWARE' => [
+           'NAME'           => 'vbox-winxp',
+        ]
+      ];
+
+      $callable = function($params) {
+         $params['source']['OPERATINGSYSTEM']['FULL_NAME'] =
+            'Fedora release 23 (Twenty Three)';
+         return $params;
+      };
+      $PLUGIN_HOOKS['fusioninventory_addinventoryinfos']['tests'] = $callable;
+
+      $pfFormatconvert = new PluginFusioninventoryFormatconvert();
+      $a_return = $pfFormatconvert->computerInventoryTransformation($a_computer);
+
+      unset($PLUGIN_HOOKS['fusioninventory_addinventoryinfos']);
+
+      $a_reference = [
+         'name'                             => 'vbox-winxp',
+         'os_licenseid'                     => '',
+         'os_license_number'                => '',
+         'domains_id'                       => '',
+         'uuid'                             => '',
+         'manufacturers_id'                 => '',
+         'computermodels_id'                => '',
+         'serial'                           => '',
+         'computertypes_id'                 => '',
+         'is_dynamic'                       => '1',
+         'operatingsystemversions_id'       => '0',
+         'operatingsystemservicepacks_id'   => '0',
+         'operatingsystems_id'              => '0'
+      ];
+
+      $this->assertArrayHasKey('OPERATINGSYSTEM', $a_return['source']);
+      $this->assertArrayHasKey('FULL_NAME', $a_return['source']['OPERATINGSYSTEM']);
+      $this->assertEquals('Fedora release 23 (Twenty Three)', $a_return['source']['OPERATINGSYSTEM']['FULL_NAME']);
+   }
 
    /**
     * @test


### PR DESCRIPTION
Calling doHook in formatconvert do not retunr correctly the plugin's values to later process.
It's mandatory to call doHookFunction, which only return plugin's values to be added.