### PR TITLE
add link criterion : device_id

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -408,6 +408,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
     * @return boolean
     */
    function showForm($agents_id, $options=array()) {
+      global $CFG_GLPI;
 
       if ($agents_id!='') {
          $this->getFromDB($agents_id);
@@ -448,6 +449,13 @@ class PluginFusioninventoryAgent extends CommonDBTM {
          echo $oComputer->getLink(1);
          echo Html::hidden('computers_id',
                            array('value' => $this->fields["computers_id"]));
+         echo "&nbsp;<a class='pointer' onclick='submitGetLink(\"".
+               $CFG_GLPI['root_doc']."/plugins/fusioninventory/front/agent.form.php\", ".
+               "{\"update\": \"update\",
+                 \"computers_id\": 0,
+                 \"id\": ".$this->fields['id'].",
+                 \"_glpi_csrf_token\": \"".Session::getNewCSRFToken()."\"});'>".
+               "<img src='".$CFG_GLPI['root_doc']."/pics/delete.png' /></a>";
       } else {
          Computer_Item::dropdownConnect("Computer", "Computer", 'computers_id',
                                         $_SESSION['glpiactive_entity']);

--- a/inc/inventorycomputerinventory.class.php
+++ b/inc/inventorycomputerinventory.class.php
@@ -232,6 +232,10 @@ class PluginFusioninventoryInventoryComputerInventory {
                  AND (!empty($a_computerinventory['Computer']['uuid']))) {
             $input['uuid'] = $a_computerinventory['Computer']['uuid'];
          }
+         if (isset($this->device_id) && !empty($this->device_id)) {
+            $input['device_id'] = $this->device_id;
+         }
+
          foreach ($a_computerinventory['networkport'] as $network) {
             if (((isset($network['virtualdev']))
                     && ($network['virtualdev'] != 1))

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -168,6 +168,10 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
       $criterias['uuid']['name']  = __('Assets to import', 'fusioninventory').' : '.__('UUID');
 
 
+      $criterias['device_id']['name']   = __('agent', 'fusioninventory').' : '.
+                                       __('Device_id', 'fusioninventory');
+
+
       $criterias['mskey']['name'] = __('Assets to import', 'fusioninventory').' : '.
                                        __('Serial of the operating system');
 
@@ -435,6 +439,7 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
                                  'hdserial',
                                  'partitionserial',
                                  'uuid',
+                                 'device_id',
                                  'mskey',
                                  'name',
                                  'itemtype',
@@ -634,6 +639,17 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
 
             case 'uuid':
                $sql_where_computer .= ' AND `uuid`="'.$input['uuid'].'"';
+               break;
+
+            case 'device_id':
+               $sql_from_temp = " LEFT JOIN `glpi_plugin_fusioninventory_agents`
+                                 ON `glpi_plugin_fusioninventory_agents`.`computers_id` = ".
+                                     "`[typetable]`.`id` ";
+               $sql_where_temp = " AND `glpi_plugin_fusioninventory_agents`.`device_id` = '".
+                                    $input["device_id"]."'";
+
+               $sql_from .= $sql_from_temp;
+               $sql_where  .= $sql_where_temp;
                break;
 
             case 'domains_id':


### PR DESCRIPTION
Add a new rule import criterion to check for a computer using the agent's device id.
It helps to linked a computer when the serial and/or uuid is missing or wrong