### PR TITLE
Link agent into ignoredimportdevice

### DIFF
--- a/inc/ignoredimportdevice.class.php
+++ b/inc/ignoredimportdevice.class.php
@@ -113,7 +113,6 @@ class PluginFusioninventoryIgnoredimportdevice extends CommonDBTM {
       $tab[4]['name']          = __('Item type');
       $tab[4]['massiveaction'] = false;
       $tab[4]['datatype']      = 'itemtypename';
-      $tab[4]['massiveaction']  = false;
 
       $tab[5]['table']     = 'glpi_entities';
       $tab[5]['field']     = 'completename';
@@ -150,6 +149,13 @@ class PluginFusioninventoryIgnoredimportdevice extends CommonDBTM {
       $tab[10]['name']            = __('Module', 'fusioninventory');
       $tab[10]['datatype']        = 'string';
       $tab[10]['massiveaction']  = false;
+
+      $tab[11]['table']         = 'glpi_plugin_fusioninventory_agents';
+      $tab[11]['field']         = 'name';
+      $tab[11]['name']          = __('Agent', 'fusioninventory');
+      $tab[11]['datatype']      = 'itemlink';
+      $tab[11]['massiveaction'] = false;
+      $tab[11]['itemlink_type'] = 'PluginFusioninventoryAgent';
 
       return $tab;
    }

--- a/inc/inventorycomputerinventory.class.php
+++ b/inc/inventorycomputerinventory.class.php
@@ -412,7 +412,19 @@ class PluginFusioninventoryInventoryComputerInventory {
          }
          $inputdb['rules_id'] = $data['_ruleid'];
          $inputdb['method'] = 'inventory';
-         $pfIgnoredimportdevice->add($inputdb);
+         $inputdb['plugin_fusioninventory_agents_id'] = $_SESSION['plugin_fusioninventory_agents_id'];
+
+         // if existing ignored device, update it
+         if ($found = $pfIgnoredimportdevice->find("`plugin_fusioninventory_agents_id` =
+                                                    '".$inputdb['plugin_fusioninventory_agents_id']."'",
+                                                   "`date` DESC",
+                                                   1)) {
+            $agent         = array_pop($found);
+            $inputdb['id'] = $agent['id'];
+            $pfIgnoredimportdevice->update($inputdb);
+         } else {
+            $pfIgnoredimportdevice->add($inputdb);
+         }
       }
    }
 

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -316,6 +316,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_ignoredimportdevices` (
    `method` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
    `serial` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
    `uuid` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+   `plugin_fusioninventory_agents_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 

--- a/install/update.php
+++ b/install/update.php
@@ -2128,12 +2128,18 @@ function do_ignoredimport_migration($migration) {
                                             'value'   => NULL);
    $a_table['fields']['uuid']       = array('type'    => 'string',
                                             'value'   => NULL);
+   $a_table['fields']['plugin_fusioninventory_agents_id']
+                                    = array('type'    => 'integer',
+                                            'value'   => NULL);
 
    $a_table['oldfields']  = array();
 
    $a_table['renamefields'] = array();
 
    $a_table['keys']   = array();
+   $a_table['keys'][] = array('field' => 'plugin_fusioninventory_agents_id',
+                              'name' => '',
+                              'type' => 'INDEX');
 
    $a_table['oldkeys'] = array();
 

--- a/phpunit/2_Integration/RuleIgnoredImportTest.php
+++ b/phpunit/2_Integration/RuleIgnoredImportTest.php
@@ -132,16 +132,17 @@ class RuleIgnoredImport extends Common_TestCase {
 
       $a_ignore = current($a_ignored);
       $a_reference = array(
-          'id'          => '1',
-          'name'        => 'pc1',
-          'itemtype'    => 'Computer',
-          'entities_id' => '0',
-          'ip'          => NULL,
-          'mac'         => NULL,
-          'rules_id'    => '48',
-          'method'      => 'inventory',
-          'serial'      => '',
-          'uuid'        => ''
+          'id'                               => '1',
+          'name'                             => 'pc1',
+          'itemtype'                         => 'Computer',
+          'entities_id'                      => '0',
+          'ip'                               => NULL,
+          'mac'                              => NULL,
+          'rules_id'                         => '48',
+          'method'                           => 'inventory',
+          'serial'                           => '',
+          'uuid'                             => '',
+          'plugin_fusioninventory_agents_id' => '1'
       );
       unset($a_ignore['date']);
       $this->assertEquals($a_ignore, $a_reference, 'Ignored import computer');


### PR DESCRIPTION
A description:
- add a new key into glpi_plugin_fusioninventory_ignoredimportdevices table for agents_id
- add a new searchoption corresponding to this key
- update existing ignored import device row when a similar entry exist (instead of always adding it)
- minor: [remove a duplicate in a searchoption of this class](https://github.com/fusioninventory/fusioninventory-for-glpi/pull/2044/files#diff-c745a6385b9b7ba9fc4e5e79f0e78c41L116)