### PR TITLE
allow install of FusionInventory from CLI using the test context of GLPI

### DIFF
--- a/scripts/cli_install.php
+++ b/scripts/cli_install.php
@@ -42,26 +42,36 @@
 
 chdir(dirname($_SERVER["SCRIPT_FILENAME"]));
 
-include ("../../../inc/includes.php");
-
 include ("./docopt.php");
 
 $doc = <<<DOC
 cli_install.php
 
 Usage:
-   cli_install.php [--no-models-update] [--force-upgrade] [--as-user USER] [--optimize]
+   cli_install.php [--no-models-update] [--force-upgrade] [--as-user USER] [--optimize] [ --tests ]
 
 Options:
    --force-upgrade      Force upgrade.
    --no-models-update   Do not perform SNMP models update.
    --as-user USER       Do install/upgrade as specified USER.
    --optimize           Optimize tables.
+   --tests              Use GLPi test database
 
 DOC;
 
 $docopt = new \Docopt\Handler();
 $args = $docopt->handle($doc);
+
+if (isset($args)) {
+   if (isset($args['--tests']) &&  $args['--tests'] !== false) {
+      // Use test GLPi's database
+      // Requires use of cliinstall of GLPI with --tests argument
+      define('GLPI_ROOT', dirname(dirname(dirname(__DIR__))));
+      define("GLPI_CONFIG_DIR", GLPI_ROOT . "/tests");
+   }
+}
+
+include ("../../../inc/includes.php");
 
 // Init debug variable
 $_SESSION['glpi_use_mode'] = Session::DEBUG_MODE;


### PR DESCRIPTION
Hi

The unit tests of GLPI provide an argument --tests which alters the directory of config_db.php. This is very convenient to unit test GLPI (and plugins) in a database different than the database I use for development (and contaning my data set).

I implemented a cli installer for a few plugins I maintain with this feature for months and fount it really convenient.

This PR give the same feature to FusionInventory.

Install GLPI in unit test context 
```php tools/cliinstall.php --db=database --user=glpi --pass=glpi --tests```

then install FusionIvnentory 
```php scripts/cli_install.php --tests```

and install other plugins and run its unit tests (for my needs).

I think this PR would be benefit FusionInventory too as it uses its own cli installer to install and unit test the database schema.

Changing FusinvInstallTest.php by adding --tests argument would be sufficient to switch to unit tests context.
