### PR TITLE
use cache on dynamic group

### DIFF
--- a/inc/deploygroup.class.php
+++ b/inc/deploygroup.class.php
@@ -412,9 +412,10 @@ class PluginFusioninventoryDeployGroup extends CommonDBTM {
     * Get targets for the group
     *
     * @param integer $groups_id id of the group
+    * @param bool    $use_cache retrieve agents from cache or not (only for dynamic groups)
     * @return array list of computers
     */
-   static function getTargetsForGroup($groups_id) {
+   static function getTargetsForGroup($groups_id, $use_cache = false) {
       $group = new self();
       $group->getFromDB($groups_id);
 
@@ -426,7 +427,8 @@ class PluginFusioninventoryDeployGroup extends CommonDBTM {
             $results[$tmpgroup['items_id']] = $tmpgroup['items_id'];
          }
       } else {
-         $results = PluginFusioninventoryDeployGroup_Dynamicdata::getTargetsByGroup($group);
+         $results = PluginFusioninventoryDeployGroup_Dynamicdata::getTargetsByGroup($group,
+                                                                                    $use_cache);
       }
       return $results;
    }

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -230,7 +230,13 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
       return $ids;
    }
 
-   static function storeCache(PluginFusioninventoryDeployGroup $group, $ids) {
+   /**
+    * Store a set of computers id in db
+    * @param  PluginFusioninventoryDeployGroup $group the instance of fi group
+    * @param  array                            $ids   the list of id to store
+    * @return bool
+    */
+   static function storeCache(PluginFusioninventoryDeployGroup $group, $ids = []) {
       global $DB;
 
       $query = "UPDATE ".self::getTable()."
@@ -239,6 +245,11 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
       return $DB->query($query);
    }
 
+   /**
+    * Retrieve the id of computer stored in db for a group
+    * @param  PluginFusioninventoryDeployGroup $group the instance of the group
+    * @return array                            the list of compuers id
+    */
    static function retrieveCache(PluginFusioninventoryDeployGroup $group) {
       global $DB;
 

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -276,7 +276,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             $actor_key = "".key($actor)."_".$actor[key($actor)];
             if (!isset($actors[$actor_key])) {
                $actors[$actor_key] = array();
-               foreach ($this->getAgentsFromActors(array($actor)) as $agent) {
+               foreach ($this->getAgentsFromActors(array($actor), true) as $agent) {
                   $actors[$actor_key][$agent] = true;
                }
             }
@@ -662,9 +662,10 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
     * corresponding itemtype classes.
     *
     * @param array $actors
+    * @param bool  $use_cache retrieve agents from cache or not
     * @return array list of agents
     */
-   public function getAgentsFromActors($actors = array()) {
+   public function getAgentsFromActors($actors = array(), $use_cache = false) {
       $agents = array();
       $computers = array();
       $computer = new Computer();
@@ -688,7 +689,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             case 'PluginFusioninventoryDeployGroup':
                $group_targets = $pfToolbox->executeAsFusioninventoryUser(
                   'PluginFusioninventoryDeployGroup::getTargetsForGroup',
-                  array($itemid)
+                  array($itemid, $use_cache)
                );
                foreach ($group_targets as $computerid) {
                   $computers[$computerid] = 1;

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -915,6 +915,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_deploygroups_dynamicdatas` (
   `plugin_fusioninventory_deploygroups_id` int(11) NOT NULL DEFAULT '0',
   `fields_array` text DEFAULT NULL,
   `can_update_group` tinyint(1) NOT NULL DEFAULT '0',
+  `computers_id_cache` text DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `plugin_fusioninventory_deploygroups_id` (`plugin_fusioninventory_deploygroups_id`),
   KEY `can_update_group` (`can_update_group`)

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -915,7 +915,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_deploygroups_dynamicdatas` (
   `plugin_fusioninventory_deploygroups_id` int(11) NOT NULL DEFAULT '0',
   `fields_array` text DEFAULT NULL,
   `can_update_group` tinyint(1) NOT NULL DEFAULT '0',
-  `computers_id_cache` text DEFAULT NULL,
+  `computers_id_cache` longtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `plugin_fusioninventory_deploygroups_id` (`plugin_fusioninventory_deploygroups_id`),
   KEY `can_update_group` (`can_update_group`)

--- a/install/update.php
+++ b/install/update.php
@@ -5584,7 +5584,7 @@ function do_deploygroup_migration($migration) {
          'value' => 0
       ),
       'computers_id_cache' =>  array(
-         'type' => 'text',
+         'type' => 'longtext',
          'value' => NULL
       ),
    );

--- a/install/update.php
+++ b/install/update.php
@@ -894,25 +894,6 @@ function pluginFusioninventoryUpdate($current_version, $migrationname='Migration
                                'comment'=>'Wake agents ups'));
    }
 
-   /**
-   * Add field to manage which group can be refreshed by updatedynamictasks crontask
-   */
-   if (!FieldExists('glpi_plugin_fusioninventory_deploygroups_dynamicdatas', 'can_update_group')) {
-      $migration->addField('glpi_plugin_fusioninventory_deploygroups_dynamicdatas', 'can_update_group', 'bool');
-      $migration->addKey('glpi_plugin_fusioninventory_deploygroups_dynamicdatas', 'can_update_group');
-      $migration->migrationOneTable('glpi_plugin_fusioninventory_deploygroups_dynamicdatas');
-   }
-
-
-      //Change static & dynamic structure to fit the GLPI framework
-      $migration->changeField('glpi_plugin_fusioninventory_deploygroups_dynamicdatas',
-                              'groups_id',
-                              'plugin_fusioninventory_deploygroups_id', 'integer');
-      $migration->migrationOneTable('glpi_plugin_fusioninventory_deploygroups_dynamicdatas');
-      $migration->changeField('glpi_plugin_fusioninventory_deploygroups_staticdatas',
-                              'groups_id', 'plugin_fusioninventory_deploygroups_id', 'integer');
-      $migration->migrationOneTable('glpi_plugin_fusioninventory_deploygroups_staticdatas');
-
 
 
    // Fix software version in computers. see https://github.com/fusioninventory/fusioninventory-for-glpi/issues/1810
@@ -5534,7 +5515,7 @@ function do_deploygroup_migration($migration) {
          'type' => 'autoincrement',
          'value' => NULL
       ),
-      'groups_id' =>  array(
+      'plugin_fusioninventory_deploygroups_id' =>  array(
          'type' => 'integer',
          'value' => NULL
       ),
@@ -5552,11 +5533,12 @@ function do_deploygroup_migration($migration) {
    );
 
    $a_table['renamefields'] = array(
+      'groups_id' => 'plugin_fusioninventory_deploygroups_id',
    );
 
    $a_table['keys'] = array(
       array(
-         'field' => 'groups_id',
+         'field' => 'plugin_fusioninventory_deploygroups_id',
          'name' => '',
          'type' => 'KEY'
       ),
@@ -5589,11 +5571,19 @@ function do_deploygroup_migration($migration) {
          'type' => 'autoincrement',
          'value' => NULL
       ),
-      'groups_id' =>  array(
+      'plugin_fusioninventory_deploygroups_id' =>  array(
          'type' => 'integer',
          'value' => NULL
       ),
       'fields_array' =>  array(
+         'type' => 'text',
+         'value' => NULL
+      ),
+      'can_update_group' =>  array(
+         'type' => 'bool',
+         'value' => 0
+      ),
+      'computers_id_cache' =>  array(
          'type' => 'text',
          'value' => NULL
       ),
@@ -5603,11 +5593,17 @@ function do_deploygroup_migration($migration) {
    );
 
    $a_table['renamefields'] = array(
+      'groups_id' => 'plugin_fusioninventory_deploygroups_id',
    );
 
    $a_table['keys'] = array(
       array(
-         'field' => 'groups_id',
+         'field' => 'plugin_fusioninventory_deploygroups_id',
+         'name' => '',
+         'type' => 'KEY'
+      ),
+      array(
+         'field' => 'can_update_group',
          'name' => '',
          'type' => 'KEY'
       ),


### PR DESCRIPTION
When demanding a b/collect/index.php?action=getJobs , 
All agent are computed again and so a dynamic group listing launch.
Depending on the criteria saved in this group, query could be very long and executed again for **each** agent of this group (imagine a deployment for 1000 computers querying the dynamic group each). 

If i understand well, the code check if an agent always belongs to a prepared job and cancel if not.
For mass deployment, it's pretty aggressive on the server.

I suggest, in this pr, to cache computers_id of dynamic groups at the preparation of the task (use_cache = false, the default), and at the moment of execution, use this cache (use_cache = true).

Maybe, we can do better for this problem, but i don't see atm.

Also cleaned some incoherence in update.php 