### PR TITLE
drop old checks for 0.84 version

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -537,19 +537,6 @@ function plugin_fusioninventory_check_prerequisites() {
       }
    }
 
-   $crontask = new CronTask();
-   if ($plugin->isActivated("fusioninventory")) {
-      if ((TableExists("glpi_plugin_fusioninventory_agents")
-              AND !FieldExists("glpi_plugin_fusioninventory_agents", "tag"))
-           OR ($crontask->getFromDBbyName('PluginFusioninventoryTaskjobstatus', 'cleantaskjob'))
-           OR (TableExists("glpi_plugin_fusioninventory_agentmodules")
-              AND FieldExists("glpi_plugin_fusioninventory_agentmodules", "url"))) {
-         $DB->query("UPDATE `glpi_plugin_fusioninventory_configs` SET `value`='0.80+1.4'
-                        WHERE `type`='version'");
-         $DB->query("UPDATE `glpi_plugins` SET `version`='0.80+1.4'
-                        WHERE `directory` LIKE 'fusi%'");
-      }
-   }
    return TRUE;
 }
 


### PR DESCRIPTION
This code seems old and not usefull for current version.
Also, it induce some very strange behaviors detected on a replicated glpi instance (lock present on slave, some tables unavailable) and a reset of link rules.

