### PR TITLE
Disconnect agent

### DIFF
--- a/front/agent.form.php
+++ b/front/agent.form.php
@@ -74,6 +74,10 @@ if (isset($_POST['startagent'])) {
    Session::checkRight('plugin_fusioninventory_agent', PURGE);
    $agent->delete($_POST, true);
    $agent->redirectToList();
+} else if (isset ($_POST["disconnect"])) {
+   Session::checkRight('plugin_fusioninventory_agent', UPDATE);
+   $agent->disconnect($_POST);
+   Html::back();
 } else if (isset ($_POST["startagent"])) {
 
    Html::back();

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -224,7 +224,9 @@ class PluginFusioninventoryAgent extends CommonDBTM {
    function getTabNameForItem(CommonGLPI $item, $withtemplate=0) {
       $tab_names = array();
       if ($this->can(0, CREATE)) {
-         if ($item->getType() == 'Computer') {
+         if ($item->getType() == 'Computer'
+            && countElementsInTable('glpi_plugin_fusioninventory_agents',
+                                    "`computers_id`=".$item->getID())) {
             $tab_names[] = __('FusInv', 'fusioninventory').' '. __('Agent');
          }
       }
@@ -451,8 +453,8 @@ class PluginFusioninventoryAgent extends CommonDBTM {
                            array('value' => $this->fields["computers_id"]));
          echo "&nbsp;<a class='pointer' onclick='submitGetLink(\"".
                $CFG_GLPI['root_doc']."/plugins/fusioninventory/front/agent.form.php\", ".
-               "{\"update\": \"update\",
-                 \"computers_id\": 0,
+               "{\"disconnect\": \"disconnect\",
+                 \"computers_id\": ".$this->fields['computers_id'].",
                  \"id\": ".$this->fields['id'].",
                  \"_glpi_csrf_token\": \"".Session::getNewCSRFToken()."\"});'>".
                "<img src='".$CFG_GLPI['root_doc']."/pics/delete.png' /></a>";
@@ -561,6 +563,18 @@ class PluginFusioninventoryAgent extends CommonDBTM {
    }
 
 
+   /**
+   * Disconnect an agent from a computer
+   * @params POST parameters
+   * @return void
+   */
+   function disconnect($params) {
+      if (isset($params['computers_id']) && isset($params['id'])) {
+         $pfComputer = new PluginFusioninventoryInventoryComputerComputer();
+         $pfComputer->deleteByCriteria(['computers_id' => $params['computers_id']]);
+         $this->update(['id' => $params['id'], 'computers_id' => 0]);
+      }
+   }
 
    /**
     * Get agent information by device_id

--- a/phpunit/1_Unit/AgentTest.php
+++ b/phpunit/1_Unit/AgentTest.php
@@ -89,29 +89,6 @@ class AgentTest extends RestoreDatabase_TestCase {
 
    /**
     * @test
-    * @depends addAgent
-    */
-   public function disconnectAgent() {
-
-      $pfAgent  = new PluginFusioninventoryAgent();
-      $agent    = $pfAgent->find(
-         "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
-      );
-      $this->assertEquals(1, count($agent));
-      $current_agent = current($agent);
-      $agent_id      = $current_agent['id'];
-
-      //Disconnect the agent from the computer
-      $pfAgent->disconnect(['computers_id' => 100, 'id' => $agent_id]);
-      $count = countElementsInTable('glpi_plugin_fusioninventory_inventorycomputercomputers',
-                                    "`computers_id`='100'");
-      $this->assertEquals(0, $count);
-
-      $pfAgent->getFromDB($agent_id);
-      $this->assertEquals(0, $pfAgent->fields['computers_id']);
-   }
-   /**
-    * @test
     */
    public function newAgentLinkedToSameAsset() {
 
@@ -197,4 +174,30 @@ class AgentTest extends RestoreDatabase_TestCase {
       $this->assertContains(date('Y-m-d'), strstr($pfAgent->fields['last_contact'], date('Y-m-d')));
       $this->assertEquals($nb, count($log->find()));
    }
+
+   /**
+    * @test
+    * @depends addAgent
+    */
+   public function disconnectAgent() {
+
+      $pfAgent  = new PluginFusioninventoryAgent();
+      $agent    = $pfAgent->find(
+         "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
+      );
+      $this->assertEquals(1, count($agent));
+      $current_agent = current($agent);
+      $agent_id      = $current_agent['id'];
+
+      //Disconnect the agent from the computer
+      $pfAgent->disconnect(['computers_id' => 100, 'id' => $agent_id]);
+      $count = countElementsInTable('glpi_plugin_fusioninventory_inventorycomputercomputers',
+                                    "`computers_id`='100'");
+      $this->assertEquals(0, $count);
+
+      //Check that computers_id has been set to 0
+      $pfAgent->getFromDB($agent_id);
+      $this->assertEquals(0, $pfAgent->fields['computers_id']);
+   }
+
 }

--- a/phpunit/1_Unit/AgentTest.php
+++ b/phpunit/1_Unit/AgentTest.php
@@ -88,6 +88,10 @@ class AgentTest extends RestoreDatabase_TestCase {
       $this->assertEquals(1, count($a_agents), "Agent not found");
    }
 
+   /**
+    * @test
+    * @depends addAgent
+    */
    public function disconnectAgent() {
       $a_agents = $pfAgent->find(
          "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"

--- a/phpunit/1_Unit/AgentTest.php
+++ b/phpunit/1_Unit/AgentTest.php
@@ -79,8 +79,7 @@ class AgentTest extends RestoreDatabase_TestCase {
     */
    public function agentExists() {
 
-      $pfAgent = new PluginFusioninventoryAgent();
-
+      $pfAgent  = new PluginFusioninventoryAgent();
       $a_agents = $pfAgent->find(
          "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
       );
@@ -93,6 +92,8 @@ class AgentTest extends RestoreDatabase_TestCase {
     * @depends addAgent
     */
    public function disconnectAgent() {
+
+      $pfAgent  = new PluginFusioninventoryAgent();
       $a_agents = $pfAgent->find(
          "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
       );

--- a/phpunit/1_Unit/AgentTest.php
+++ b/phpunit/1_Unit/AgentTest.php
@@ -88,6 +88,23 @@ class AgentTest extends RestoreDatabase_TestCase {
       $this->assertEquals(1, count($a_agents), "Agent not found");
    }
 
+   public function disconnectAgent() {
+      $a_agents = $pfAgent->find(
+         "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
+      );
+      $this->assertEquals(1, count($agent));
+      $current_agent = current($agent);
+      $agent_id      = $current_agent['id'];
+
+      //Disconnect the agent from the computer
+      $pfAgent->disconnect(['computers_id' => 100, 'id' => $agent_id]);
+      $count = countElementsInTable('glpi_plugin_fusioninventory_inventorycomputercomputers',
+                                    "`computers_id`='100'");
+      $this->assertEquals(0, $count);
+
+      $pfAgent->getFromDB($agent_id);
+      $this->assertEquals(0, $pfAgent->fields['computers_id']);
+   }
    /**
     * @test
     */
@@ -176,4 +193,3 @@ class AgentTest extends RestoreDatabase_TestCase {
       $this->assertEquals($nb, count($log->find()));
    }
 }
-

--- a/phpunit/1_Unit/AgentTest.php
+++ b/phpunit/1_Unit/AgentTest.php
@@ -94,7 +94,7 @@ class AgentTest extends RestoreDatabase_TestCase {
    public function disconnectAgent() {
 
       $pfAgent  = new PluginFusioninventoryAgent();
-      $a_agents = $pfAgent->find(
+      $agent    = $pfAgent->find(
          "`device_id` = 'port004.bureau.siprossii.com-2013-01-01-16-27-27'"
       );
       $this->assertEquals(1, count($agent));


### PR DESCRIPTION
When disconnecting an agent from a computer, remove agent related information in fusioninventory tables.
Do not also display the FusionInventory Agent tab is not agent linked to a computer.