### PR TITLE
Add computer's hostid as the agent now retrieves it

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -245,7 +245,7 @@ function plugin_fusioninventory_getAddSearchOptions($itemtype) {
                                                                                                  'joinparams' => array('jointype' => 'child')))));
 
          $sopt[5178]['table']     = 'glpi_plugin_fusioninventory_inventorycomputercomputers';
-         $sopt[5178]['field']     = 'oscomment';
+         $sopt[5178]['field']     = 'hostid';
          $sopt[5178]['name']      = __('HostID', 'fusioninventory');
          $sopt[5178]['joinparams']  = array('jointype' => 'child');
          $sopt[5178]['massiveaction'] = FALSE;

--- a/hook.php
+++ b/hook.php
@@ -244,6 +244,11 @@ function plugin_fusioninventory_getAddSearchOptions($itemtype) {
                                                      'joinparams' => array('beforejoin' => array('table' => 'glpi_plugin_fusioninventory_inventorycomputercomputers',
                                                                                                  'joinparams' => array('jointype' => 'child')))));
 
+         $sopt[5178]['table']     = 'glpi_plugin_fusioninventory_inventorycomputercomputers';
+         $sopt[5178]['field']     = 'oscomment';
+         $sopt[5178]['name']      = __('HostID', 'fusioninventory');
+         $sopt[5178]['joinparams']  = array('jointype' => 'child');
+         $sopt[5178]['massiveaction'] = FALSE;
    }
 
    if ($itemtype == 'Computer') {
@@ -2433,8 +2438,20 @@ function postShowtab($params) {
                    );
 
                    echo "</td>";
+
                    echo "</tr>";
+
+                   echo "</tr>";
+
                 }
+
+                echo "<tr class='tab_bg_1'>";
+                echo "<td>".__('HostID', 'fusioninventory')."</td>";
+                echo "<td>";
+                echo $a_computerextend['hostid'];
+                echo "</td>";
+                echo "</tr>";
+
                 echo '</table>';
                 break;
              }

--- a/hook.php
+++ b/hook.php
@@ -2438,9 +2438,6 @@ function postShowtab($params) {
                    );
 
                    echo "</td>";
-
-                   echo "</tr>";
-
                    echo "</tr>";
 
                 }

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -488,6 +488,11 @@ class PluginFusioninventoryFormatconvert {
                     'ARCH'           => 'operatingsystemarchitectures_id',
                     'KERNEL_NAME'    => 'plugin_fusioninventory_computeroskernelnames_id',
                     'KERNEL_VERSION' => 'plugin_fusioninventory_computeroskernelversions_id'));
+
+         if (isset($array['OPERATINGSYSTEM']['HOSTID'])) {
+            $a_inventory['fusioninventorycomputer']['hostid'] = $array['OPERATINGSYSTEM']['HOSTID'];
+         }
+
          $array_tmp['plugin_fusioninventory_computeroperatingsystemeditions_id'] = '';
          if (isset($array['OPERATINGSYSTEM']['FULL_NAME']) && $pfConfig->getValue('manage_osname') == 1) {
             $matches = array();

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -407,6 +407,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_inventorycomputercomputers` (
   `serialized_inventory` longblob,
   `is_entitylocked` tinyint(1) NOT NULL DEFAULT '0',
   `oscomment` text DEFAULT NULL,
+  `hostid` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `computers_id` (`computers_id`),
   KEY `last_fusioninventory_update` (`last_fusioninventory_update`)

--- a/install/update.php
+++ b/install/update.php
@@ -4992,6 +4992,9 @@ function do_computeroperatingsystem_migration($migration) {
 
    migrateTablesFusionInventory($migration, $a_table);
 
+   $migration->addField('glpi_plugin_fusioninventory_inventorycomputercomputers',
+                        "hostid", "string", ['after' => 'oscomment']);
+   $migration->migrationOneTable('glpi_plugin_fusioninventory_inventorycomputercomputers');
 }
 
 

--- a/phpunit/1_Unit/ComputerUpdateTest.php
+++ b/phpunit/1_Unit/ComputerUpdateTest.php
@@ -371,7 +371,8 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
           'remote_addr'                               => NULL,
           'plugin_fusioninventory_computeroperatingsystems_id' => 0,
           'is_entitylocked'                           => 0,
-          'oscomment'                                 => NULL
+          'oscomment'                                 => NULL,
+          'hostid'                                    => NULL
       );
 
       $this->assertEquals($a_reference, $a_computer);


### PR DESCRIPTION
Retrieve and display computers hostid.
This information may be used by software vendors for licensing purpose.