### PR TITLE
clone with branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,8 @@ addons:
 
 before_install:
  - cd ..
- - git clone --depth=10 git://github.com/glpi-project/glpi.git glpi
+ - git clone --depth=10 -b $GLPI git://github.com/glpi-project/glpi.git glpi
  - cd glpi
- - if [[ $GLPI != '9.1/bugfixes' ]]; then git checkout -b $GLPI origin/$GLPI; fi
  - composer install --no-dev -o
  - cd ..
  - mysql -u root -e "SET PASSWORD FOR 'travis'@'localhost' = PASSWORD('travis')"


### PR DESCRIPTION
Fix regression added in https://github.com/fusioninventory/fusioninventory-for-glpi/commit/e09b6d6

The glpi default branch is now 9.1/bugfixes and with the shallow clone (--depth=10), we don't have other branches available.

So i added '-b' option to directly precise the branch