### PR TITLE
don't append edit_job on redirect if id is null, fix a notice

### DIFF
--- a/inc/taskjobview.class.php
+++ b/inc/taskjobview.class.php
@@ -55,7 +55,7 @@ if (!defined('GLPI_ROOT')) {
 class PluginFusioninventoryTaskjobView extends PluginFusioninventoryCommonView {
 
    /**
-    * __contruct function where initialize base URLs 
+    * __contruct function where initialize base URLs
     */
    function __construct() {
       parent::__construct();
@@ -833,9 +833,13 @@ class PluginFusioninventoryTaskjobView extends PluginFusioninventoryCommonView {
             $this->update($postvars);
          }
 
+         $add_redirect = "";
+         if ($jobs_id) {
+            $add_redirect = "&edit_job=$jobs_id#taskjobs_form";
+         }
+
          Html::redirect($CFG_GLPI["root_doc"]."/plugins/fusioninventory/front/task.form.php?id=".
-                                 $postvars['plugin_fusioninventory_tasks_id']."&edit_job=".$jobs_id.
-                                 "#taskjobs_form");
+                                 $postvars['plugin_fusioninventory_tasks_id'].$add_redirect);
       } else if (isset($postvars["delete"])) {
          // * delete taskjob
          Session::checkRight('plugin_fusioninventory_task', PURGE);


### PR DESCRIPTION
Current master only

added by this previous commit: 
https://github.com/fusioninventory/fusioninventory-for-glpi/commit/7783926dc67d2170832917854244394a7f5399e8#diff-7fd1588c26666307b62d6d529d8f01aaR837

the notice:
```
  *** PHP Notice(8): Undefined index: id
  Backtrace :
  ...s/fusioninventory/inc/taskjobview.class.php:503 
  ...s/fusioninventory/inc/taskjobview.class.php:173 PluginFusioninventoryTaskjobView->showForm()
  plugins/fusioninventory/ajax/taskjob_form.php:65   PluginFusioninventoryTaskjobView->ajaxGetForm()

```