### PR TITLE
filter actor dropdown in tasks

### DIFF
--- a/ajax/taskjob_moduleitems.php
+++ b/ajax/taskjob_moduleitems.php
@@ -57,6 +57,7 @@ $pfTaskjob = new PluginFusioninventoryTaskjob();
 $params = array(
     "moduletype" => filter_input(INPUT_GET, "moduletype"),
     "itemtype"   => filter_input(INPUT_GET, "itemtype"),
+    "method"     => filter_input(INPUT_GET, "method"),
 );
 
 $pfTaskjob->ajaxModuleItemsDropdown($params);


### PR DESCRIPTION
The dropdown will show only agents or computers which have the module enabled (or in global conf).
I tested on a db with > 10k agents, i had a tiny lag to display the second dropdown (<500ms).


Before:
![image](https://cloud.githubusercontent.com/assets/418844/25897991/6ffba6d6-358a-11e7-836e-c6085abec8fc.png)


After:
![image](https://cloud.githubusercontent.com/assets/418844/25897967/53e8ae26-358a-11e7-8b27-057f6a9be9e9.png)
