### PR TITLE
Fix value interpretation in deploy audits

### DIFF
--- a/inc/deploycheck.class.php
+++ b/inc/deploycheck.class.php
@@ -715,7 +715,6 @@ class PluginFusioninventoryDeployCheck extends CommonDBTM {
     * @param array $params list of fields with value of the check
     */
    static function add_item($params) {
-
       if (!isset($params['value'])) {
          $params['value'] = "";
       }
@@ -723,7 +722,9 @@ class PluginFusioninventoryDeployCheck extends CommonDBTM {
          $params['name'] = "";
       }
 
-      if (!empty($params['value']) && is_numeric($params['value'])) {
+      if (!empty($params['value'])
+         && is_numeric($params['value'])
+            && !empty($params['unit'])) {
          $params['value'] = $params['value'] * self::getUnitSize($params['unit']);
 
          //Make an exception for freespaceGreater check which is saved as MiB
@@ -737,7 +738,7 @@ class PluginFusioninventoryDeployCheck extends CommonDBTM {
          'name'   => $params['name'],
          'type'   => $params['deploy_checktype'],
          'path'   => $params['path'],
-         'value'  => $params['value'],
+         'value'  => strval($params['value']),
          'return' => $params['return']
       );
 

--- a/phpunit/1_Unit/Deploy/DeploycheckTest.php
+++ b/phpunit/1_Unit/Deploy/DeploycheckTest.php
@@ -442,7 +442,7 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
                  'return'             => 'skip'
               ];
       PluginFusioninventoryDeployCheck::add_item($params);
-      $expected = '{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\\Software\\FusionInventory-Agent\\debug","value":false,"return":"skip"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
+      $expected = '{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":"","return":"skip"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
       $json     = Toolbox::stripslashes_deep(PluginFusioninventoryDeployPackage::getJson($packages_id));
       $this->assertEquals($expected, $json);
 
@@ -455,7 +455,20 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
                  'return'             => 'info'
               ];
       PluginFusioninventoryDeployCheck::add_item($params);
-      $expected = '{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":false,"return":"skip"},{"name":"More than 500 Mb","type":"freespaceGreater","path":"/tmp","value":500,"return":"info"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
+      $expected = '{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":"","return":"skip"},{"name":"More than 500 Mb","type":"freespaceGreater","path":"/tmp","value":"500","return":"info"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
+      $json     = Toolbox::stripslashes_deep(PluginFusioninventoryDeployPackage::getJson($packages_id));
+      $this->assertEquals($expected, $json);
+
+      $params = ['id'                 => $packages_id,
+                 'name'               => 'Test with float',
+                 'deploy_checktype'   => 'winkeyEquals',
+                 'path'               => 'HKEY_LOCAL_MACHINE\SOFTWARE\FusionInventory-Agent\debug',
+                 'value'              => '9.20',
+                 'unit'               => '',
+                 'return'             => 'info'
+              ];
+      PluginFusioninventoryDeployCheck::add_item($params);
+      $expected = ''{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":"","return":"skip"},{"name":"More than 500 Mb","type":"freespaceGreater","path":"/tmp","value":"500","return":"info"},{"name":"Test with float","type":"winkeyEquals","path":"HKEY_LOCAL_MACHINE\SOFTWARE\FusionInventory-Agent\debug","value":"9.20","return":"info"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
       $json     = Toolbox::stripslashes_deep(PluginFusioninventoryDeployPackage::getJson($packages_id));
       $this->assertEquals($expected, $json);
 

--- a/phpunit/1_Unit/Deploy/DeploycheckTest.php
+++ b/phpunit/1_Unit/Deploy/DeploycheckTest.php
@@ -468,7 +468,7 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
                  'return'             => 'info'
               ];
       PluginFusioninventoryDeployCheck::add_item($params);
-      $expected = ''{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":"","return":"skip"},{"name":"More than 500 Mb","type":"freespaceGreater","path":"/tmp","value":"500","return":"info"},{"name":"Test with float","type":"winkeyEquals","path":"HKEY_LOCAL_MACHINE\SOFTWARE\FusionInventory-Agent\debug","value":"9.20","return":"info"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
+      $expected = '{"jobs":{"checks":[{"name":"Value exists","type":"winvalueExists","path":"HKLM\Software\FusionInventory-Agent\debug","value":"","return":"skip"},{"name":"More than 500 Mb","type":"freespaceGreater","path":"/tmp","value":"500","return":"info"},{"name":"Test with float","type":"winkeyEquals","path":"HKEY_LOCAL_MACHINE\SOFTWARE\FusionInventory-Agent\debug","value":"9.20","return":"info"}],"associatedFiles":[],"actions":[]},"associatedFiles":[]}';
       $json     = Toolbox::stripslashes_deep(PluginFusioninventoryDeployPackage::getJson($packages_id));
       $this->assertEquals($expected, $json);
 


### PR DESCRIPTION
Value is not well saved in database for an deployment audit value.
For example 9.20 will be stored in the JSON array as 9.2