### PR TITLE
Deploymirror migration and searchoption

### DIFF
--- a/inc/deploymirror.class.php
+++ b/inc/deploymirror.class.php
@@ -312,6 +312,12 @@ class PluginFusioninventoryDeployMirror extends CommonDBTM {
       $tab[2]['name']      = __('Mirror server address', 'fusioninventory');
       $tab[2]['datatype']  = 'string';
 
+      $tab[3]['table']     = $this->getTable();
+      $tab[3]['field']     = 'is_active';
+      $tab[3]['linkfield'] = 'is_active';
+      $tab[3]['name']      = __('Active');
+      $tab[3]['datatype']  = 'bool';
+
       $tab[16]['table']     = $this->getTable();
       $tab[16]['field']     = 'comment';
       $tab[16]['linkfield'] = 'comment';

--- a/install/update.php
+++ b/install/update.php
@@ -5434,12 +5434,21 @@ function do_deploypackage_migration($migration) {
  * @param object $migration
  */
 function do_deploymirror_migration($migration) {
+   global $DB;
 
    /*
     * glpi_plugin_fusioninventory_deploymirrors
     */
 
    $a_table = array();
+
+   //If table doesn't exists, then we're sure the is_active field is not present
+   if (!$DB->tableExists('glpi_plugin_fusioninventory_deploymirrors')) {
+      $is_active_exists = false;
+   } else {
+      $is_active_exists = ($DB->fieldExists('glpi_plugin_fusioninventory_deploymirrors',
+                                       'is_active'));
+   }
 
    //table name
    $a_table['name'] = 'glpi_plugin_fusioninventory_deploymirrors';
@@ -5520,6 +5529,13 @@ function do_deploymirror_migration($migration) {
    );
 
    migrateTablesFusionInventory($migration, $a_table);
+
+   //During migration, once the is_active field is added,
+   //all mirrors must be active to keep compatibility
+   if (!$is_active_exists) {
+      $query = "UPDATE `glpi_plugin_fusioninventory_deploymirrors` SET `is_active`='1'";
+      $DB->query($query);
+   }
 }
 
 

--- a/phpunit/0_Install/FusinvDB.php
+++ b/phpunit/0_Install/FusinvDB.php
@@ -311,7 +311,6 @@ class FusinvDB extends PHPUnit_Framework_Assert{
       $result = $DB->query($query);
       $this->assertEquals($DB->numrows($result), 8760, "Must have table `glpi_plugin_fusioninventory_inventorycomputerstats` not empty");
 
-
    }
 }
 

--- a/phpunit/0_Install/FusinvUpdateTest.php
+++ b/phpunit/0_Install/FusinvUpdateTest.php
@@ -111,7 +111,8 @@ class UpdateTest extends RestoreDatabase_TestCase {
       $FusinvDB->checkInstall("fusioninventory", "upgrade from ".$version);
 
       $this->verifyEntityRules($nbrules);
-
+      $this->checkDeployMirrors();
+      
       if ($verify) {
          $this->verifyConfig();
       }
@@ -161,6 +162,16 @@ class UpdateTest extends RestoreDatabase_TestCase {
       $a_config = current($a_configs);
       $this->assertEquals(1, $a_config['value'], "May keep states_id_default to 1");
    }
+
+   private function checkDeployMirrors() {
+      global $DB;
+
+      //check is the field is_active has correctly been added to mirror servers
+      $this->assertTrue($DB->fieldExists('glpi_plugin_fusioninventory_deploymirrors',
+                                    'is_active'));
+
+   }
+
 }
 
 ?>


### PR DESCRIPTION
Enable existing mirror by default during migration.
Add search options for deploymirror.is_active