### PR TITLE
fix warning in timeslot form

### DIFF
--- a/inc/timeslotentry.class.php
+++ b/inc/timeslotentry.class.php
@@ -189,9 +189,9 @@ class PluginFusioninventoryTimeslotEntry extends CommonDBTM {
 
       $dbentries = getAllDatasFromTable(
                      'glpi_plugin_fusioninventory_timeslotentries',
-                     "`plugin_fusioninventory_timeslots_id`='".$timeslots_id."'",
+                     ['plugin_fusioninventory_timeslots_id' => $timeslots_id],
                      '',
-                     '`day`, `begin` ASC');
+                     ['day', 'begin ASC']);
 
       $options = array();
       $this->initForm(key($dbentries), $options);


### PR DESCRIPTION
when displaying a timeslot form: 
```log
2017-10-20 09:37:43 [2@LU002]
  *** MySQL query error:
  SQL: SELECT * FROM `glpi_plugin_fusioninventory_timeslotentries` WHERE `plugin_fusioninventory_timeslots_id`=\'1\' ORDER BY `day`,
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 1
  Backtrace :
  inc/dbmysqliterator.class.php:264                  
  inc/dbmysql.class.php:540                          DBmysqlIterator->__construct()
  inc/dbutils.class.php:441                          DBmysql->request()
  inc/db.function.php:270                            DbUtils->getAllDataFromTable()
  ...fusioninventory/inc/timeslotentry.class.php:194 getAllDatasFromTable()
  ...fusioninventory/inc/timeslotentry.class.php:173 PluginFusioninventoryTimeslotEntry->formDeleteEntry()
  plugins/fusioninventory/inc/timeslot.class.php:281 PluginFusioninventoryTimeslotEntry->formEntry()
  inc/commonglpi.class.php:472                       PluginFusioninventoryTimeslot->showForm()
  ajax/common.tabs.php:96                            CommonGLPI::displayStandardTab()
```