### PR TITLE
avoid importing disks with empty serial

### DIFF
--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -458,6 +458,13 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             } else {
                foreach ($a_computerinventory['harddrive'] as $key => $arrays) {
                   $arrayslower = array_map('strtolower', $arrays);
+
+                  // if disk has no serial, don't add and unset it
+                  if (!isset($arrayslower['serial'])) {
+                     unset($a_computerinventory['harddrive'][$key]);
+                     break;
+                  }
+
                   foreach ($db_harddrives as $keydb => $arraydb) {
                      if ($arrayslower['serial'] == $arraydb['serial']) {
                         if ($arraydb['capacity'] == 0
@@ -1507,7 +1514,9 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
          $input = array();
          $input['itemtype'] = "Monitor";
          $input['name']     = $arrays['name'];
-         $input['serial']   = $arrays['serial'];
+         $input['serial']   = isset($arrays['serial'])
+                               ? $arrays['serial']
+                               : "";
          $data = $rule->processAllRules($input, array(), array('class'=>$this, 'return' => TRUE));
          if (isset($data['found_equipment'])) {
             if ($data['found_equipment'][0] == 0) {
@@ -1591,7 +1600,9 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
          $input = array();
          $input['itemtype'] = "Printer";
          $input['name']     = $arrays['name'];
-         $input['serial']   = $arrays['serial'];
+         $input['serial']   = isset($arrays['serial'])
+                               ? $arrays['serial']
+                               : "";
          $data = $rule->processAllRules($input, array(), array('class'=>$this, 'return' => TRUE));
          if (isset($data['found_equipment'])) {
             if ($data['found_equipment'][0] == 0) {
@@ -1670,7 +1681,9 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
          $input = array();
          $input['itemtype'] = "Peripheral";
          $input['name']     = $arrays['name'];
-         $input['serial']   = $arrays['serial'];
+         $input['serial']   = isset($arrays['serial'])
+                               ? $arrays['serial']
+                               : "";
          $data = $rule->processAllRules($input, array(), array('class'=>$this, 'return' => TRUE));
          if (isset($data['found_equipment'])) {
             if ($data['found_equipment'][0] == 0) {


### PR DESCRIPTION
Actually, the missing serial in $arraydb causes a lot of log in php_errors.log
Ex on 0.85 (already seen in recent versions):
```
*** PHP Notice(8): Undefined index: serial
  Backtrace :
  ...nventory/inc/inventorycomputerlib.class.php:347
  ...ry/inc/inventorycomputerinventory.class.php:566 PluginFusioninventoryInventoryComputerLib->updateComputer()
  ...inventory/inc/inventoryruleimport.class.php:719 PluginFusioninventoryInventoryComputerInventory->rulepassed()
  inc/rule.class.php:1402                            PluginFusioninventoryInventoryRuleImport->executeActions()
  inc/rulecollection.class.php:1455                  Rule->process()
  ...ry/inc/inventorycomputerinventory.class.php:369 RuleCollection->processAllRules()
  ...ry/inc/inventorycomputerinventory.class.php:108 PluginFusioninventoryInventoryComputerInventory->sendCriteria()
  ...fusioninventory/inc/communication.class.php:222 PluginFusioninventoryInventoryComputerInventory->import()
  ...fusioninventory/inc/communication.class.php:452 PluginFusioninventoryCommunication->import()
  plugins/fusioninventory/front/communication.php:88 PluginFusioninventoryCommunication->handleOCSCommunication()
  plugins/fusioninventory/index.php:51               include_once()
```

I think we have 2 solutions, 
- don't import disks with non-set serials (i choose this one)
- force serial to empty string when it doesn't exists.

I fear the second solution may causes some data overwriting when we have multiple disks with no serials