### PR TITLE
prevent timeslot display when failing to check entities

### DIFF
--- a/inc/timeslotentry.class.php
+++ b/inc/timeslotentry.class.php
@@ -194,7 +194,9 @@ class PluginFusioninventoryTimeslotEntry extends CommonDBTM {
                      ['day', 'begin ASC']);
 
       $options = array();
-      $this->initForm(key($dbentries), $options);
+      $ID      = key($dbentries);
+      $canedit = $this->getFromDB($ID)
+                 && $this->can($ID, READ);
       $this->showFormHeader($options);
 
       foreach ($dbentries as $dbentry) {
@@ -212,7 +214,9 @@ class PluginFusioninventoryTimeslotEntry extends CommonDBTM {
          echo PluginFusioninventoryToolbox::getHourMinute($dbentry['end']);
          echo "</td>";
          echo "<td colspan='2'>";
-         echo "<input type='submit' class='submit' name='purge-".$dbentry['id']."' value='delete' />";
+         if ($canedit) {
+            echo "<input type='submit' class='submit' name='purge-".$dbentry['id']."' value='delete' />";
+         }
          echo "</td>";
          echo "</tr>";
       }


### PR DESCRIPTION
Case:
- timeslot entries is_recursive = no and its timeslot parent have is_recursive = yes
- global entity selector set to another entity than entries one:

Without patch:
![image](https://user-images.githubusercontent.com/418844/32045462-9c016bcc-ba40-11e7-90d3-b0c4b7d61abf.png)

---
With (note the absence of delete buttons):
![image](https://user-images.githubusercontent.com/418844/32045540-d5d80cb6-ba40-11e7-9fbd-d28413f3aa16.png)

