### PR TITLE
inventory infos should not be displayed on computer creation (id <= 0)

### DIFF
--- a/inc/inventorycomputercomputer.class.php
+++ b/inc/inventorycomputercomputer.class.php
@@ -170,7 +170,8 @@ class PluginFusioninventoryInventoryComputerComputer extends CommonDBTM {
    static function showFormForAgentWithNoInventory($item) {
       $id = $item->getID();
       $pfComputer  = new self();
-      if (!empty($pfComputer->hasAutomaticInventory($id))) {
+      if ($item->isNewItem()
+          || !empty($pfComputer->hasAutomaticInventory($id))) {
          return true;
       } else {
          $pfAgent = new PluginFusioninventoryAgent();


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/418844/32047320-dd83527c-ba45-11e7-9f86-ae2361793cbc.png)
