### PR TITLE
default states_id should not erase locked states_id

### DIFF
--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -197,7 +197,9 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             $history = FALSE;
          }
          $input['_no_history'] = $no_history;
-         $input = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('computer', $input);
+         if (!in_array('states_id', $a_lockable)) {
+            $input = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('computer', $input);
+         }
          $computer->update($input, !$no_history);
 
       $this->computer = $computer;

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -790,11 +790,15 @@ class PluginFusioninventoryToolbox {
       $config = new PluginFusioninventoryConfig();
       switch ($type) {
          case 'computer':
-            $input['states_id'] = $config->getValue("states_id_default");
+            if ($states_id_default = $config->getValue("states_id_default")) {
+               $input['states_id'] = $states_id_default;
+            }
             break;
 
          case 'snmp':
-            $input['states_id'] = $config->getValue("states_id_snmp_default");
+            if ($states_id_snmp_default = $config->getValue("states_id_snmp_default")) {
+               $input['states_id'] = $states_id_snmp_default;
+            }
             break;
 
          default:


### PR DESCRIPTION
fix #2286

Also added a test in addDefaultStateIfNeeded to prevent set of states_id when defaut equals to 0