### PR TITLE
prevent notice when lock set on name

### DIFF
--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -184,7 +184,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
 
       // * Computer
          $db_computer = $computer->fields;
-         $computerName = $a_computerinventory['Computer']['name'];
+         $computerName = $computer->fields['name'];
          $a_ret = PluginFusioninventoryToolbox::checkLock($a_computerinventory['Computer'],
                                                           $db_computer, $a_lockable);
          $a_computerinventory['Computer'] = $a_ret[0];


### PR DESCRIPTION
fix the notice present when name is locked (and does not exist in ``$a_computerinventory``)
``$computerName`` is used only for construct history

```log
2017-11-09 09:11:17 [27@LU002]
  *** PHP Notice(8): Undefined index: name
  Backtrace :
  ...nventory/inc/inventorycomputerlib.class.php:187 
  ...ry/inc/inventorycomputerinventory.class.php:577 PluginFusioninventoryInventoryComputerLib->updateComputer()
  ...inventory/inc/inventoryruleimport.class.php:790 PluginFusioninventoryInventoryComputerInventory->rulepassed()
  inc/rule.class.php:1436                            PluginFusioninventoryInventoryRuleImport->executeActions()
  inc/rulecollection.class.php:1461                  Rule->process()
  ...ry/inc/inventorycomputerinventory.class.php:378 RuleCollection->processAllRules()
  ...ry/inc/inventorycomputerinventory.class.php:126 PluginFusioninventoryInventoryComputerInventory->sendCriteria()
  ...fusioninventory/inc/communication.class.php:235 PluginFusioninventoryInventoryComputerInventory->import()
  ...fusioninventory/inc/communication.class.php:463 PluginFusioninventoryCommunication->import()
  ...ventory/front/inventorycomputerimportxml.php:97 PluginFusioninventoryCommunication->handleOCSCommunication()
```