### PR TITLE
WIP Add default state for monitor / printer / peripheral

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -124,6 +124,9 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       $input['component_removablemedia'] = 0;
       $input['states_id_default']      = 0;
       $input['states_id_snmp_default'] = 0;
+      $input['states_id_printer_default'] = 0;
+      $input['states_id_monitor_default'] = 0;
+      $input['states_id_peripheral_default'] = 0;
       $input['location']               = 0;
       $input['group']                  = 0;
       $input['create_vm']              = 0;
@@ -737,12 +740,39 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       echo "</tr>";
 
       echo "<tr class='tab_bg_1'>";
-      echo "<td>".__('Default status', 'fusioninventory')."</td>";
+      echo "<td>".__('Default status for network equipment', 'fusioninventory')."</td>";
       echo "<td>";
       Dropdown::show('State',
                      array('name'   => 'states_id_snmp_default',
                            'value'  => $pfConfig->getValue('states_id_snmp_default')));
       echo "</td><td colspan='2'></td></tr>";
+
+
+      echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Default status for printer', 'fusioninventory')."</td>";
+      echo "<td>";
+      Dropdown::show('State',
+                     array('name'   => 'states_id_printer_default',
+                           'value'  => $pfConfig->getValue('states_id_printer_default')));
+      echo "</td><td colspan='2'></td></tr>";
+
+            echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Default status for monitor', 'fusioninventory')."</td>";
+      echo "<td>";
+      Dropdown::show('State',
+                     array('name'   => 'states_id_monitor_default',
+                           'value'  => $pfConfig->getValue('states_id_monitor_default')));
+      echo "</td><td colspan='2'></td></tr>";
+
+            echo "<tr class='tab_bg_1'>";
+      echo "<td>".__('Default status for peripheral', 'fusioninventory')."</td>";
+      echo "<td>";
+      Dropdown::show('State',
+                     array('name'   => 'states_id_peripheral_default',
+                           'value'  => $pfConfig->getValue('states_id_peripheral_default')));
+      echo "</td><td colspan='2'></td></tr>";
+
+
 
       echo "<tr class='tab_bg_1'>";
       echo "<td>".__('Threads number', 'fusioninventory')."&nbsp;".

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -1524,6 +1524,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             if ($data['found_equipment'][0] == 0) {
                // add monitor
                $arrays['entities_id'] = $entities_id;
+               $arrays = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('monitor', $arrays);
                $a_monitors[] = $monitor->add($arrays);
             } else {
                $a_monitors[] = $data['found_equipment'][0];
@@ -1610,6 +1611,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             if ($data['found_equipment'][0] == 0) {
                // add printer
                $arrays['entities_id'] = $entities_id;
+               $arrays = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('printer', $arrays);
                $a_printers[] = $printer->add($arrays);
             } else {
                $a_printers[] = $data['found_equipment'][0];
@@ -1691,6 +1693,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             if ($data['found_equipment'][0] == 0) {
                // add peripheral
                $arrays['entities_id'] = $entities_id;
+               $arrays = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('peripheral', $arrays);
                $a_peripherals[] = $peripheral->add($arrays);
             } else {
                $a_peripherals[] = $data['found_equipment'][0];

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -801,6 +801,24 @@ class PluginFusioninventoryToolbox {
             }
             break;
 
+         case 'printer':
+            if ($states_id_printer_default = $config->getValue("states_id_printer_default")) {
+               $input['states_id'] = $states_id_printer_default;
+            }
+            break;
+
+         case 'monitor':
+            if ($states_id_monitor_default = $config->getValue("states_id_monitor_default")) {
+               $input['states_id'] = $states_id_monitor_default;
+            }
+            break;
+
+         case 'peripheral':
+            if ($states_id_peripheral_default = $config->getValue("states_id_peripheral_default")) {
+               $input['states_id'] = $states_id_peripheral_default;
+            }
+            break;
+
          default:
             $state = false;
             break;

--- a/phpunit/1_Unit/ToolboxTest.php
+++ b/phpunit/1_Unit/ToolboxTest.php
@@ -93,16 +93,32 @@ JSON;
       $state = new State();
       $states_id_computer = $state->importExternal('state_computer');
       $states_id_snmp = $state->importExternal('state_snmp');
+      $states_id_printer = $state->importExternal('state_printer');
+      $states_id_monitor = $state->importExternal('state_monitor');
+      $states_id_peripheral = $state->importExternal('state_peripheral');
 
       $config = new PluginFusioninventoryConfig();
       $config->updateValue('states_id_snmp_default', $states_id_snmp);
+      $config->updateValue('states_id_printer_default', $states_id_printer);
+      $config->updateValue('states_id_monitor_default', $states_id_monitor);
+      $config->updateValue('states_id_peripheral_default', $states_id_peripheral);
       $config->updateValue('states_id_default', $states_id_computer);
+
 
       $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('computer', $input);
       $this->assertEquals(['states_id' => $states_id_computer], $result);
 
       $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('snmp', $input);
       $this->assertEquals(['states_id' => $states_id_snmp], $result);
+
+      $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('printer', $input);
+      $this->assertEquals(['states_id' => $states_id_printer], $result);
+
+      $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('monitor', $input);
+      $this->assertEquals(['states_id' => $states_id_monitor], $result);
+
+      $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('peripheral', $input);
+      $this->assertEquals(['states_id' => $states_id_peripheral], $result);
 
       $result = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('foo', $input);
       $this->assertEquals([], $result);


### PR DESCRIPTION
On inventory network configuration add new fields to manage default state for prionter / monitor and peripheral.

![image](https://user-images.githubusercontent.com/7335054/32775745-9c71ccc4-c930-11e7-92ca-00cb4540a837.png)

The status is used at the creation.