### PR TITLE
rework taskjobs counters

### DIFF
--- a/phpunit/2_Integration/Tasks/CronTaskTest.php
+++ b/phpunit/2_Integration/Tasks/CronTaskTest.php
@@ -438,11 +438,10 @@ class CronTaskTest extends RestoreDatabase_TestCase {
           'agents_success' => array(
               '1' => 1
           ),
-          'agents_error' => array(
-              '3' => 2
-          ),
+          'agents_error' => array(),
           'agents_notdone' => array(
-              '4' => 3
+              '4' => 3,
+              '3' => 2
           )
       );
       $counters = $data['tasks'][1]['jobs'][1]['targets']['PluginFusioninventoryDeployPackage_1']['counters'];


### PR DESCRIPTION
Ok, THESE jobs counters bother me from long time and today i went with shovel to remove all complexity.

I think, let me know if i'm wrong, the counters should "resume" the last state of an agent.
If, in the log, we have for the same agent:
- job 2 -> prepared
- job 1 -> error 
The counter `In error` should not count this agent, only `Prepared` (and `Not done yet` in cons)

So now, only the last state influence the counters, we remove **older** states before adding a new one

Nota: this PR is very readable with side by side diff, not at all in unified