### PR TITLE
run collect shouldnt delete old content for other agents

### DIFF
--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -581,10 +581,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                    'uuid'     => $taskjobstate->fields['uniqid'],
                    '_sid'     => $reg['id']
                );
-               //clean old registries results
-               $query = "DELETE FROM `glpi_plugin_fusioninventory_collects_registries_contents`
-                         WHERE `plugin_fusioninventory_collects_registries_id`='".$reg['id']."'";
-               $DB->query($query);
             }
             break;
 
@@ -602,11 +598,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                   $datawmi['moniker'] = $wmi['moniker'];
                }
                $output[] = $datawmi;
-
-               //clean old wmi results
-               $query = "DELETE FROM `glpi_plugin_fusioninventory_collects_wmis_contents`
-                         WHERE `plugin_fusioninventory_collects_wmis_id`='".$wmi['id']."'";
-               $DB->query($query);
             }
 
             break;
@@ -653,7 +644,8 @@ class PluginFusioninventoryCollect extends CommonDBTM {
 
                //clean old files
                $query = "DELETE FROM `glpi_plugin_fusioninventory_collects_files_contents`
-                         WHERE `plugin_fusioninventory_collects_files_id`='".$files['id']."'";
+                         WHERE `plugin_fusioninventory_collects_files_id`='".$files['id']."'
+                           AND `computers_id` = '".$agent['computers_id']."'";
                $DB->query($query);
             }
             break;


### PR DESCRIPTION
I dropped some parts of collect which delete old content because:
- it deletes all data (also for others computers)
- it's redundant with another parts of code (ex for registry: https://github.com/fusioninventory/fusioninventory-for-glpi/blob/master/inc/collect_registry_content.class.php#L177)

For files collect, the [updateComputer](https://github.com/fusioninventory/fusioninventory-for-glpi/blob/master/inc/collect_file_content.class.php#L149-L159) part doesn't have the deletion process, so i kept the query, but i added the filter on computers_id to avoid data deletion for others computers