### PR TITLE
Drop os id from comparison to prevent migration related issues

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -1600,13 +1600,11 @@ class PluginFusioninventoryFormatconvert {
                   $comp_key = strtolower($array_tmp['name']).
                                "$$$$".strtolower($array_tmp['version']).
                                "$$$$".$array_tmp['manufacturers_id'].
-                               "$$$$".$array_tmp['entities_id'].
-                               "$$$$".$array_tmp['operatingsystems_id'];
+                               "$$$$".$array_tmp['entities_id'];
 
                   $comp_key_simple = strtolower($array_tmp['name']).
                                "$$$$".strtolower($array_tmp['version']).
-                               "$$$$".$array_tmp['entities_id'].
-                               "$$$$".$array_tmp['operatingsystems_id'];
+                               "$$$$".$array_tmp['entities_id'];
 
                   if ($array_tmp['manufacturers_id'] == 0) {
                      $softwareWithoutManufacturer[$comp_key_simple] = $array_tmp;
@@ -1625,8 +1623,7 @@ class PluginFusioninventoryFormatconvert {
             $comp_key = strtolower($array_tmp['name']).
                          "$$$$".strtolower($array_tmp['version']).
                          "$$$$".$array_tmp['manufacturers_id'].
-                         "$$$$".$array_tmp['entities_id'].
-                         "$$$$".$array_tmp['operatingsystems_id'];
+                         "$$$$".$array_tmp['entities_id'];
             if (!isset($a_inventory['software'][$comp_key])) {
                $a_inventory['software'][$comp_key] = $array_tmp;
             }

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -843,8 +843,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                   $comp_key = strtolower($data['name']).
                                "$$$$".strtolower($data['version']).
                                "$$$$".$data['manufacturers_id'].
-                               "$$$$".$data['entities_id'].
-                               "$$$$".$data['operatingsystems_id'];
+                               "$$$$".$data['entities_id'];
                   $db_software[$comp_key] = $idtmp;
                }
             }

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -819,7 +819,6 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                           `glpi_softwareversions`.`name` AS version,
                           `glpi_softwares`.`manufacturers_id`,
                           `glpi_softwareversions`.`entities_id`,
-                          `glpi_softwareversions`.`operatingsystems_id`,
                           `glpi_computers_softwareversions`.`is_template_computer`,
                           `glpi_computers_softwareversions`.`is_deleted_computer`
                    FROM `glpi_computers_softwareversions`
@@ -907,7 +906,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                                            $lastSoftwareVid);
                foreach ($a_computerinventory['software'] as $a_software) {
                   $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                  if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']])) {
+                  if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id])) {
                      $this->addSoftwareVersion($a_software, $softwares_id);
                   }
                }
@@ -917,7 +916,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                $a_toinsert = array();
                foreach ($a_computerinventory['software'] as $a_software) {
                   $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                  $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']];
+                  $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id];
                   $a_tmp = array(
                       'computers_id'        => $computers_id,
                       'softwareversions_id' => $softwareversions_id,
@@ -936,7 +935,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                   if (!$no_history) {
                      foreach ($a_computerinventory['software'] as $a_software) {
                         $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                        $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']];
+                        $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id];
 
                         $changes[0] = '0';
                         $changes[1] = "";
@@ -1033,7 +1032,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                                                  $lastSoftwareVid);
                      foreach ($a_computerinventory['software'] as $a_software) {
                         $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                        if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']])) {
+                        if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id])) {
                            $this->addSoftwareVersion($a_software, $softwares_id);
                         }
                      }
@@ -1043,7 +1042,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                      $a_toinsert = array();
                      foreach ($a_computerinventory['software'] as $a_software) {
                         $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                        $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']];
+                        $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id];
                         $a_tmp = array(
                             'computers_id'        => $computers_id,
                             'softwareversions_id' => $softwareversions_id,
@@ -1061,7 +1060,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
                      if (!$no_history) {
                         foreach ($a_computerinventory['software'] as $a_software) {
                            $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-                           $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']];
+                           $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id];
 
                            $changes[0] = '0';
                            $changes[1] = "";
@@ -2414,7 +2413,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
       $a_versions = array();
       foreach ($a_softVersion as $a_software) {
          $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-         if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']])) {
+         if (!isset($this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id])) {
             $a_versions[$a_software['version']][] = $softwares_id;
          }
       }
@@ -2422,11 +2421,11 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
       $nbVersions = 0;
       foreach ($a_versions as $name=>$a_softwares_id) {
          foreach ($a_softwares_id as $softwares_id) {
-            $arr[] = "'".$name."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']."'";
+            $arr[] = "'".$name."$$$$".$softwares_id."'";
          }
          $nbVersions++;
       }
-      $whereid .= " AND CONCAT_WS('$$$$', `name`, `softwares_id`, `operatingsystems_id`) IN ( ";
+      $whereid .= " AND CONCAT_WS('$$$$', `name`, `softwares_id`) IN ( ";
       $whereid .= implode(',', $arr);
       $whereid .= " ) ";
 
@@ -2441,11 +2440,11 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
          return $lastid;
       }
 
-      $sql = "SELECT `id`, `name`, `softwares_id`, `operatingsystems_id` FROM `glpi_softwareversions`
+      $sql = "SELECT `id`, `name`, `softwares_id` FROM `glpi_softwareversions`
       WHERE `entities_id`='".$entities_id."'".$whereid;
       $result = $DB->query($sql);
       while ($data = $DB->fetch_assoc($result)) {
-         $this->softVersionList[strtolower($data['name'])."$$$$".$data['softwares_id']."$$$$".$data['operatingsystems_id']] = $data['id'];
+         $this->softVersionList[strtolower($data['name'])."$$$$".$data['softwares_id']] = $data['id'];
       }
 
       return $lastid;
@@ -2484,7 +2483,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
       $a_software['_no_history']  = TRUE;
       $softwareversions_id = $this->softwareVersion->add($a_software, $options, FALSE);
       $this->addPrepareLog($softwareversions_id, 'SoftwareVersion');
-      $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']] = $softwareversions_id;
+      $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id] = $softwareversions_id;
    }
 
 
@@ -2536,7 +2535,7 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
       $options['disable_unicity_check'] = TRUE;
 
       $softwares_id = $this->softList[$a_software['name']."$$$$".$a_software['manufacturers_id']];
-      $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id."$$$$".$a_software['operatingsystems_id']];
+      $softwareversions_id = $this->softVersionList[strtolower($a_software['version'])."$$$$".$softwares_id];
 
       $this->softwareVersion->getFromDB($softwareversions_id);
       $a_software['computers_id']         = $computers_id;

--- a/phpunit/1_Unit/ComputerLogTest.php
+++ b/phpunit/1_Unit/ComputerLogTest.php
@@ -228,7 +228,7 @@ class ComputerLog extends RestoreDatabase_TestCase {
                     'is_dynamic'             => 1,
                     'operatingsystems_id'    => 0
                 ),
-            'orbit2$$$$2.14.19$$$$3' => Array(
+            'orbit2$$$$2.14.19$$$$3$$$$0' => Array(
                     'name'                   => 'ORBit2',
                     'version'                => '2.14.19',
                     'manufacturers_id'       => 3,

--- a/phpunit/1_Unit/ComputerLogTest.php
+++ b/phpunit/1_Unit/ComputerLogTest.php
@@ -208,7 +208,7 @@ class ComputerLog extends RestoreDatabase_TestCase {
         );
 
       $this->a_inventory['software'] = Array(
-            'gentiumbasic$$$$110$$$$1$$$$0$$$$0' => Array(
+            'gentiumbasic$$$$110$$$$1$$$$0' => Array(
                     'name'                   => 'GentiumBasic',
                     'version'                => 110,
                     'manufacturers_id'       => 1,
@@ -218,7 +218,7 @@ class ComputerLog extends RestoreDatabase_TestCase {
                     'is_dynamic'             => 1,
                     'operatingsystems_id'    => 0
                 ),
-            'imagemagick$$$$6.8.0.7_1$$$$2$$$$0$$$$0' => Array(
+            'imagemagick$$$$6.8.0.7_1$$$$2$$$$0' => Array(
                     'name'                   => 'ImageMagick',
                     'version'                => '6.8.0.7_1',
                     'manufacturers_id'       => 2,
@@ -228,7 +228,7 @@ class ComputerLog extends RestoreDatabase_TestCase {
                     'is_dynamic'             => 1,
                     'operatingsystems_id'    => 0
                 ),
-            'orbit2$$$$2.14.19$$$$3$$$$0$$$$0' => Array(
+            'orbit2$$$$2.14.19$$$$3' => Array(
                     'name'                   => 'ORBit2',
                     'version'                => '2.14.19',
                     'manufacturers_id'       => 3,
@@ -372,7 +372,7 @@ class ComputerLog extends RestoreDatabase_TestCase {
       // * Remove a software
       $this->a_inventory['Computer']['contact'] = 'root';
       unset($this->a_inventory['processor'][3]);
-      unset($this->a_inventory['software']['orbit2$$$$2.14.19$$$$3$$$$0$$$$0']);
+      unset($this->a_inventory['software']['orbit2$$$$2.14.19$$$$3$$$$0']);
 
       $DB->query('TRUNCATE `glpi_logs`');
       $pfiComputerLib->updateComputer($this->a_inventory, 1, FALSE);

--- a/phpunit/1_Unit/ComputerUpdateTest.php
+++ b/phpunit/1_Unit/ComputerUpdateTest.php
@@ -243,7 +243,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
         );
 
       $a_inventory['software'] = Array(
-            'gentiumbasic$$$$110$$$$1$$$$0$$$$0' => Array(
+            'gentiumbasic$$$$110$$$$1$$$$0' => Array(
                     'name'                   => 'GentiumBasic',
                     'version'                => 110,
                     'manufacturers_id'       => 1,
@@ -252,7 +252,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
                     'is_deleted_computer'    => 0,
                     'operatingsystems_id'    => 0
                 ),
-            'imagemagick$$$$6.8.0.7_1$$$$2$$$$0$$$$0' => Array(
+            'imagemagick$$$$6.8.0.7_1$$$$2$$$$0' => Array(
                     'name'                   => 'ImageMagick',
                     'version'                => '6.8.0.7_1',
                     'manufacturers_id'       => 2,
@@ -261,7 +261,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
                     'is_deleted_computer'    => 0,
                     'operatingsystems_id'    => 0
                 ),
-            'orbit2$$$$2.14.19$$$$3$$$$0$$$$0' => Array(
+            'orbit2$$$$2.14.19$$$$3$$$$0' => Array(
                     'name'                   => 'ORBit2',
                     'version'                => '2.14.19',
                     'manufacturers_id'       => 3,
@@ -1261,7 +1261,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
           'contact'                          => 'ddurieux'
       );
       $a_inventory['software'] = Array(
-            'acrobat_reader_9.2$$$$1.0.0.0$$$$192$$$$0$$$$0' => Array(
+            'acrobat_reader_9.2$$$$1.0.0.0$$$$192$$$$0' => Array(
                     'name'                   => 'acrobat_Reader_9.2',
                     'version'                => '1.0.0.0',
                     'manufacturers_id'       => 192,

--- a/phpunit/1_Unit/SoftwareUpdateTest.php
+++ b/phpunit/1_Unit/SoftwareUpdateTest.php
@@ -170,7 +170,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
       $a_return = $pfFormatconvert->computerSoftwareTransformation($a_software, 0);
 
       $a_reference = array();
-      $a_reference['software']["fusioninventory$$$$0.85+1.0$$$$1$$$$0$$$$0"] = array(
+      $a_reference['software']["fusioninventory$$$$0.85+1.0$$$$1$$$$0"] = array(
                'name'                  => 'fusioninventory',
                'manufacturers_id'      => 1,
                'version'               => '0.85+1.0',
@@ -243,7 +243,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
       $a_return = $pfFormatconvert->computerSoftwareTransformation($a_software, 0);
 
       $a_reference = array();
-      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0$$$$0"] = array(
+      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0"] = array(
                'name'                  => 'glpi',
                'manufacturers_id'      => 2,
                'version'               => '0.85',
@@ -289,7 +289,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
       $a_return = $pfFormatconvert->computerSoftwareTransformation($a_software, 0);
 
       $a_reference = array();
-      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0$$$$0"] = array(
+      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0"] = array(
                'name'                  => 'glpi',
                'manufacturers_id'      => 2,
                'version'               => '0.85',
@@ -330,7 +330,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
       $a_return = $pfFormatconvert->computerSoftwareTransformation($a_software, 0);
 
       $a_reference = array();
-      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0$$$$0"] = array(
+      $a_reference['software']["glpi$$$$0.85$$$$2$$$$0"] = array(
                'name'                  => 'glpi',
                'manufacturers_id'      => '2',
                'version'               => '0.85',
@@ -390,7 +390,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
       $a_return = $pfFormatconvert->computerSoftwareTransformation($a_software, 0);
 
       $a_reference = array();
-      $a_reference['software']["audacity 2.0.4$$$$2.0.4$$$$3$$$$0$$$$0"] = array(
+      $a_reference['software']["audacity 2.0.4$$$$2.0.4$$$$3$$$$0"] = array(
                'name'                  => 'Audacity 2.0.4',
                'manufacturers_id'      => 3,
                'version'               => '2.0.4',
@@ -402,7 +402,7 @@ class SoftwareUpdateTest extends RestoreDatabase_TestCase {
                'date_install'          => '2013-10-16',
                '_system_category'      => 'application'
             );
-      $a_reference['software']["autoit v3.3.8.1$$$$$$$$4$$$$0$$$$0"] = array(
+      $a_reference['software']["autoit v3.3.8.1$$$$$$$$4$$$$0"] = array(
                'name'                  => 'AutoIt v3.3.8.1',
                'manufacturers_id'      => 4,
                'version'               => '',

--- a/phpunit/2_Integration/SoftwareVersionAddTest.php
+++ b/phpunit/2_Integration/SoftwareVersionAddTest.php
@@ -259,12 +259,12 @@ class SoftwareVersionAddTest extends RestoreDatabase_TestCase {
 
       $arrayinventory['CONTENT']['OPERATINGSYSTEM']['NAME'] = 'Windows XP';
       $pfici->sendCriteria('TESTAAAA', $arrayinventory);
-      $this->assertEquals(count($softversion_ids) + 2, count(array_keys($softwareVersion->find())));
+      $this->assertEquals(count($softversion_ids), count(array_keys($softwareVersion->find())));
 
       $arrayinventory['CONTENT']['HARDWARE']['NAME'] = 'portdavid_3';
       $arrayinventory['CONTENT']['OPERATINGSYSTEM']['NAME'] = 'Windows';
       $pfici->sendCriteria('TESTAAAA', $arrayinventory);
-      $this->assertEquals(count($softversion_ids) + 2, count(array_keys($softwareVersion->find())));
+      $this->assertEquals(count($softversion_ids), count(array_keys($softwareVersion->find())));
 
    }
 


### PR DESCRIPTION
The issue: OS id was not correctly set previously. On the first inventory on a 9.2, this is fixed.... But all software are removed and reinstalled.