### PR TITLE
display licence fullname if not empty

### DIFF
--- a/inc/computerlicenseinfo.class.php
+++ b/inc/computerlicenseinfo.class.php
@@ -120,7 +120,7 @@ class PluginFusioninventoryComputerLicenseInfo extends CommonDBTM {
                   ."&nbsp;(".implode(', ', $options).")";
             }
             echo "<td>";
-            if (!isset($licenseInfo['fullname'])) {
+            if (!empty($licenseInfo['fullname'])) {
                echo $licenseInfo['fullname'];
             } else {
                echo $licenseInfo['name'];


### PR DESCRIPTION
Ex in xml:

```xml
<COMPONENTS>Access/AccessRuntime/Excel/ExcelConsumer/Groove/InfoPath/OneNote/Outlook/OutlookStandard/PowerPoint/Project/Publisher/SharePointDesigner/Visio/VisioSDK/Word/WordConsumer</COMPONENTS>
      <FULLNAME>Microsoft Office Professionnel 2010</FULLNAME>
      <KEY>...</KEY>
      <NAME>Microsoft Office</NAME>
      <OEM>1</OEM>
      <PRODUCTID>...</PRODUCTID>
      <TRIAL>0</TRIAL>
    </LICENSEINFOS>
```
