### PR TITLE
deploy module should be enabled by default

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -294,7 +294,7 @@ function pluginFusioninventoryInstall($version, $migrationname='Migration') {
 
       $input = array();
       $input['modulename'] = "DEPLOY";
-      $input['is_active']  = 0;
+      $input['is_active']  = 1;
       $input['exceptions'] = exportArrayToDB(array());
       $pfAgentmodule->add($input);
 


### PR DESCRIPTION
As collect (on by default like inventory) and to easing deploy usage, module for deploy should be enabled by default on plugin installation.