### PR TITLE
Display a link to the task currently using the package

### DIFF
--- a/inc/deploypackage.class.php
+++ b/inc/deploypackage.class.php
@@ -287,7 +287,7 @@ class PluginFusioninventoryDeployPackage extends CommonDBTM {
 
          foreach ($this->running_tasks as $task) {
             $taskurl =
-               PluginFusioninventoryDeployPackage::getFormURLWithID($task['task']['id'], true);
+               PluginFusioninventoryTask::getFormURLWithID($task['task']['id'], true);
             $error_message .= "<a href='$taskurl'>".$task['task']['name']."</a>, ";
          }
          $error_message .= "</div>";


### PR DESCRIPTION
When a package is used by a task, a message appears to warn the user.
The link, in this message is incorrect, point to the package form instead of the task form