### PR TITLE
Fix #2398 - Dynamic computers groups search result

### DIFF
--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -126,7 +126,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
       if (isset($params['metacriteria']) && !is_array($params['metacriteria'])) {
          $params['metacriteria'] = [];
       }
-      $params['target'] = PluginFusioninventoryDeployGroup::getFormURLWithID($item->getID(), true);
+      $params['target'] = PluginFusioninventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], true);
 
       $data = Search::prepareDatasForSearch('PluginFusioninventoryComputer', $params);
       Search::constructSQL($data);
@@ -178,7 +178,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
                $params['metacriteria'] = [];
             }
 
-            $params['target'] = PluginFusioninventoryDeployGroup::getFormURLWithID($item->getID(), true);
+            $params['target'] = PluginFusioninventoryDeployGroup::getSearchEngineTargetURL($_GET['id'], true);
             self::showList('PluginFusioninventoryComputer', $params, array('1', '2'));
             return TRUE;
 

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -88,9 +88,56 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
 
       if (!$withtemplate
           && $item->fields['type'] == PluginFusioninventoryDeployGroup::DYNAMIC_GROUP) {
-         return array(_n('Criterion', 'Criteria', 2), _n('Associated item','Associated items', 2));
+         $tabs[1] = _n('Criterion', 'Criteria', 2);
+         // Get the count of matching items
+         $count = self::getMatchingItemsCount($item);
+         if ($_SESSION['glpishow_count_on_tabs']) {
+            $tabs[2] = self::createTabEntry(_n('Associated item','Associated items', $count), $count);
+         } else {
+            $tabs[2] = _n('Associated item','Associated items', $count);
+         }
+         return $tabs;
       }
       return '';
+   }
+
+
+
+   /**
+    * Get the count of items matching the dynamic search criteria
+    *
+    * @param object $item the item object
+    * @param integer $withtemplate 1 if is a template form
+    * @return string name of the tab
+    */
+   function getMatchingItemsCount(CommonGLPI $item) {
+
+      $params_dyn = array();
+      foreach (array('sort', 'order', 'start') as $field) {
+         if (isset($_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field])) {
+            $params_dyn[$field] = $_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field];
+         }
+      }
+      $params = PluginFusioninventoryDeployGroup::getSearchParamsAsAnArray($item, false);
+      $params['massiveactionparams']['extraparams']['id'] = $_GET['id'];
+      foreach ($params_dyn as $key => $value) {
+         $params[$key] = $value;
+      }
+      if (isset($params['metacriteria']) && !is_array($params['metacriteria'])) {
+         $params['metacriteria'] = array();
+      }
+      $params['target'] = Toolbox::getItemTypeFormURL("PluginFusioninventoryDeployGroup" , true).
+         "?id=".$item->getID();
+
+      $data = Search::prepareDatasForSearch('PluginFusioninventoryComputer', $params);
+      Search::constructSQL($data);
+      // Force search in the Glpi computers
+      $data['sql']['search'] = str_replace("`mainitemtype` = 'PluginFusioninventoryComputer'",
+         "`mainitemtype` = 'Computer'", $data['sql']['search']);
+      // Only get the request count
+      Search::constructDatas($data, $onlycount = true);
+
+      return $data['data']['totalcount'];
    }
 
 
@@ -106,7 +153,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
    static function displayTabContentForItem(CommonGLPI $item, $tabnum=1, $withtemplate=0) {
       switch ($tabnum) {
 
-         case 0:
+         case 1:
             $search_params = PluginFusioninventoryDeployGroup::getSearchParamsAsAnArray($item, false);
             if (isset($search_params['metacriteria']) && empty($search_params['metacriteria'])) {
                unset($search_params['metacriteria']);
@@ -114,7 +161,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
             PluginFusioninventoryDeployGroup::showCriteria($item, $search_params);
             return TRUE;
 
-         case 1:
+         case 2:
             $params_dyn = array();
             foreach (array('sort', 'order', 'start') as $field) {
                if (isset($_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field])) {
@@ -134,7 +181,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
 
             $params['target'] = Toolbox::getItemTypeFormURL("PluginFusioninventoryDeployGroup" , true).
                                 "?id=".$item->getID();
-            self::showList('PluginFusioninventoryComputer', $params, array('2', '1'));
+            self::showList('PluginFusioninventoryComputer', $params, array('1', '2'));
             return TRUE;
 
       }
@@ -157,10 +204,14 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
       $data['sql']['search'] = str_replace("`mainitemtype` = 'PluginFusioninventoryComputer'",
               "`mainitemtype` = 'Computer'", $data['sql']['search']);
       Search::constructDatas($data);
+      // Remove some fields from the displayed columns
       if (Session::isMultiEntitiesMode()) {
-         $data['data']['cols'] = array_slice($data['data']['cols'], 0, 2);
+         // Remove entity and computer Id
+         unset($data['data']['cols'][1]);
+         unset($data['data']['cols'][2]);
       } else {
-         $data['data']['cols'] = array_slice($data['data']['cols'], 0, 1);
+         // Remove computer Id
+         unset($data['data']['cols'][1]);
       }
       Search::displayDatas($data);
    }

--- a/inc/deploygroup_dynamicdata.class.php
+++ b/inc/deploygroup_dynamicdata.class.php
@@ -112,7 +112,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
     */
    function getMatchingItemsCount(CommonGLPI $item) {
 
-      $params_dyn = array();
+      $params_dyn = [];
       foreach (array('sort', 'order', 'start') as $field) {
          if (isset($_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field])) {
             $params_dyn[$field] = $_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field];
@@ -124,10 +124,9 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
          $params[$key] = $value;
       }
       if (isset($params['metacriteria']) && !is_array($params['metacriteria'])) {
-         $params['metacriteria'] = array();
+         $params['metacriteria'] = [];
       }
-      $params['target'] = Toolbox::getItemTypeFormURL("PluginFusioninventoryDeployGroup" , true).
-         "?id=".$item->getID();
+      $params['target'] = PluginFusioninventoryDeployGroup::getFormURLWithID($item->getID(), true);
 
       $data = Search::prepareDatasForSearch('PluginFusioninventoryComputer', $params);
       Search::constructSQL($data);
@@ -162,7 +161,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
             return TRUE;
 
          case 2:
-            $params_dyn = array();
+            $params_dyn = [];
             foreach (array('sort', 'order', 'start') as $field) {
                if (isset($_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field])) {
                   $params_dyn[$field] = $_SESSION['glpisearch']['PluginFusioninventoryComputer'][$field];
@@ -176,11 +175,10 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
             }
 
             if (isset($params['metacriteria']) && !is_array($params['metacriteria'])) {
-               $params['metacriteria'] = array();
+               $params['metacriteria'] = [];
             }
 
-            $params['target'] = Toolbox::getItemTypeFormURL("PluginFusioninventoryDeployGroup" , true).
-                                "?id=".$item->getID();
+            $params['target'] = PluginFusioninventoryDeployGroup::getFormURLWithID($item->getID(), true);
             self::showList('PluginFusioninventoryComputer', $params, array('1', '2'));
             return TRUE;
 
@@ -226,7 +224,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
     * @param array $forcedisplay
     * @return array
     */
-   static function getDatas($itemtype, $params, array $forcedisplay=array()) {
+   static function getDatas($itemtype, $params, array $forcedisplay=[]) {
       $data = Search::prepareDatasForSearch($itemtype, $params, $forcedisplay);
       Search::constructSQL($data);
       Search::constructDatas($data);
@@ -246,7 +244,7 @@ class PluginFusioninventoryDeployGroup_Dynamicdata extends CommonDBChild {
     * @return an array of computer ids
     */
    static function getTargetsByGroup(PluginFusioninventoryDeployGroup $group, $use_cache = false) {
-      $ids = array();
+      $ids = [];
 
       if (!$use_cache || !$ids = self::retrieveCache($group)) {
          $search_params = PluginFusioninventoryDeployGroup::getSearchParamsAsAnArray($group, false,true);

--- a/inc/deploygroup_staticdata.class.php
+++ b/inc/deploygroup_staticdata.class.php
@@ -150,6 +150,7 @@ class PluginFusioninventoryDeployGroup_Staticdata extends CommonDBRelation{
     * @param object $item PluginFusioninventoryDeployGroup instance
     */
    static function showCriteriaAndSearch(PluginFusioninventoryDeployGroup $item) {
+      // WITH checking post values
       $search_params = PluginFusioninventoryDeployGroup::getSearchParamsAsAnArray($item, true);
       //If metacriteria array is empty, remove it as it displays the metacriteria form,
       //and it's is not we want !


### PR DESCRIPTION
Fix #2398 and add the matching items count on the Associated items tab.

Include a search preview under the search form for a preview of the search result.

This makes it much more comfortable to view the results of a search 😉 
