### PR TITLE
Fix/maria102

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,47 @@
 language: php
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - nightly
-
-matrix:
-  allow_failures:
-    - php: nightly
 
 env:
-#  - GLPI=0.90/bugfixes
-#  - GLPI=0.85/bugfixes
-#  - GLPI=9.1/bugfixes
-  - GLPI=9.2/bugfixes
+  global:
+    - GLPI=9.2/bugfixes
+    - DB=mysql
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-addons:
-  apt:
-    packages:
-    - ant
-    - xsltproc
+matrix:
+  include:
+    - php: 5.6
+      addons:
+        apt:
+          packages:
+            - ant
+            - xsltproc
+    - php: 7.0
+      addons:
+        mariadb: 10.2
+        apt:
+          packages:
+            - ant
+            - xsltproc
+    - php: 7.1
+      env: CS=true
+      addons:
+        mariadb: 10.1
+        apt:
+          packages:
+            - ant
+            - xsltproc
+    - php: 7.2
+      addons:
+        apt:
+          packages:
+            - ant
+            - xsltproc
+    - php: nightly
+  allow_failures:
+    - php: nightly
+    - php: 7.2
 
 before_install:
  - cd ..
@@ -44,6 +62,7 @@ before_script:
   - php -S localhost:8088 -t glpi > /dev/null 2>&1 &
 
 script:
+ - mysql -u root -e 'select version();'
  - ant -Dclearsavepoint='true' -Dbasedir=. -f ./glpi/plugins/fusioninventory/phpunit/build.xml phpunit.all
 
 after_script:

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -228,7 +228,7 @@ CREATE TABLE IF NOT EXISTS `glpi_plugin_fusioninventory_unmanageds` (
    `sysdescr` text DEFAULT NULL,
    `plugin_fusioninventory_configsecurities_id` int(11) NOT NULL DEFAULT '0',
    `is_dynamic` tinyint(1) NOT NULL DEFAULT '0',
-   `serialized_inventory` longblob,
+   `serialized_inventory` longblob DEFAULT NULL,
    PRIMARY KEY (`id`),
    KEY `entities_id` (`entities_id`),
    KEY `plugin_fusioninventory_agents_id` (`plugin_fusioninventory_agents_id`),
@@ -381,7 +381,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_inventorycomputercomputers` (
   `wincompany` varchar(255) DEFAULT NULL,
   `last_fusioninventory_update` datetime DEFAULT NULL,
   `remote_addr` varchar(255) DEFAULT NULL,
-  `serialized_inventory` longblob,
+  `serialized_inventory` longblob DEFAULT NULL,
   `is_entitylocked` tinyint(1) NOT NULL DEFAULT '0',
   `oscomment` text DEFAULT NULL,
   `hostid` varchar(255) DEFAULT NULL,
@@ -444,7 +444,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_networkequipments` (
    `memory` int(11) NOT NULL DEFAULT '0',
    `last_fusioninventory_update` datetime DEFAULT NULL,
    `last_PID_update` int(11) NOT NULL DEFAULT '0',
-   `serialized_inventory` longblob,
+   `serialized_inventory` longblob DEFAULT NULL,
    PRIMARY KEY (`id`),
    KEY `networkequipments_id` (`networkequipments_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
@@ -472,7 +472,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_printers` (
    `plugin_fusioninventory_configsecurities_id` int(11) NOT NULL DEFAULT '0',
    `frequence_days` int(5) NOT NULL DEFAULT '1',
    `last_fusioninventory_update` datetime DEFAULT NULL,
-   `serialized_inventory` longblob,
+   `serialized_inventory` longblob DEFAULT NULL,
    PRIMARY KEY (`id`),
    UNIQUE KEY `unicity` (`printers_id`),
    KEY `plugin_fusioninventory_configsecurities_id` (`plugin_fusioninventory_configsecurities_id`),
@@ -970,7 +970,7 @@ DROP TABLE IF EXISTS `glpi_plugin_fusioninventory_dblockinventorynames`;
 
 CREATE TABLE `glpi_plugin_fusioninventory_dblockinventorynames` (
   `value` varchar(100) NOT NULL DEFAULT '',
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
    PRIMARY KEY (`value`),
    UNIQUE KEY `value` (`value`)
 ) ENGINE=MEMORY  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
@@ -981,7 +981,7 @@ DROP TABLE IF EXISTS `glpi_plugin_fusioninventory_dblockinventories`;
 
 CREATE TABLE `glpi_plugin_fusioninventory_dblockinventories` (
   `value` int(11) NOT NULL DEFAULT '0',
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
    PRIMARY KEY (`value`),
    UNIQUE KEY `value` (`value`)
 ) ENGINE=MEMORY  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
@@ -992,7 +992,7 @@ DROP TABLE IF EXISTS `glpi_plugin_fusioninventory_dblocksoftwares`;
 
 CREATE TABLE `glpi_plugin_fusioninventory_dblocksoftwares` (
   `value` tinyint(1) NOT NULL DEFAULT '0',
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
    PRIMARY KEY (`value`),
    UNIQUE KEY `value` (`value`)
 ) ENGINE=MEMORY  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
@@ -1003,7 +1003,7 @@ DROP TABLE IF EXISTS `glpi_plugin_fusioninventory_dblocksoftwareversions`;
 
 CREATE TABLE `glpi_plugin_fusioninventory_dblocksoftwareversions` (
   `value` tinyint(1) NOT NULL DEFAULT '0',
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
    PRIMARY KEY (`value`),
    UNIQUE KEY `value` (`value`)
 ) ENGINE=MEMORY  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;

--- a/install/update.php
+++ b/install/update.php
@@ -1419,7 +1419,7 @@ function do_config_migration($migration) {
                               'name' => 'unicity',
                               'type' => 'UNIQUE');
 
-   $a_table['oldkeys'] = array();
+   $a_table['oldkeys'] = array('unicity');
 
    migrateTablesFusionInventory($migration, $a_table);
 
@@ -2566,7 +2566,7 @@ function do_computercomputer_migration($migration) {
    $a_table['fields']['remote_addr']            = array('type'    => 'string',
                                                         'value'   => NULL);
    $a_table['fields']['serialized_inventory']   = array('type'    => 'longblob',
-                                                        'value'   => "");
+                                                        'value'   => null);
    $a_table['fields']['is_entitylocked']        = array('type'    => 'bool',
                                                         'value'   => "0");
    $a_table['fields']['oscomment']              = array('type'    => 'text',
@@ -4952,7 +4952,7 @@ function do_deployfile_migration($migration) {
                'value'  => NULL
       ),
       'is_recursive' => array(
-               'type'   => 'tinyint(1) NOT NULL DEFAULT 0',
+               'type'   => 'tinyint(1) NOT NULL DEFAULT \'0\'',
                'value'  => 0
       ),
       'date_mod' => array(
@@ -5068,7 +5068,7 @@ function do_deploypackage_migration($migration) {
                'value' => NULL
       ),
       'is_recursive' =>  array(
-               'type' => 'tinyint(1) NOT NULL DEFAULT 0',
+               'type' => 'tinyint(1) NOT NULL DEFAULT \'0\'',
                'value' => NULL
       ),
       'date_mod' =>  array(
@@ -5323,11 +5323,11 @@ function do_deploymirror_migration($migration) {
          'value' => NULL
       ),
       'is_active' =>  array(
-         'type' => 'tinyint(1) NOT NULL DEFAULT 0',
+         'type' => 'tinyint(1) NOT NULL DEFAULT \'0\'',
          'value' => NULL
       ),
       'is_recursive' =>  array(
-         'type' => 'tinyint(1) NOT NULL DEFAULT 0',
+         'type' => 'tinyint(1) NOT NULL DEFAULT \'0\'',
          'value' => NULL
       ),
       'name' =>  array(
@@ -5586,7 +5586,7 @@ function do_dblocks_migration($migration) {
       $a_table['fields']  = array();
       $a_table['fields']['value']      = array('type'    => "varchar(100) NOT NULL DEFAULT ''",
                                                'value'   => NULL);
-      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
+      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP()',
                                                'value'   => NULL);
 
       $a_table['oldfields']  = array();
@@ -5612,7 +5612,7 @@ function do_dblocks_migration($migration) {
       $a_table['fields']  = array();
       $a_table['fields']['value']      = array('type'    => 'integer',
                                                'value'   => NULL);
-      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
+      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP()',
                                                'value'   => NULL);
 
       $a_table['oldfields']  = array();
@@ -5638,7 +5638,7 @@ function do_dblocks_migration($migration) {
       $a_table['fields']  = array();
       $a_table['fields']['value']      = array('type'    => 'bool',
                                                'value'   => NULL);
-      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
+      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP()',
                                                'value'   => NULL);
 
       $a_table['oldfields']  = array();
@@ -5664,7 +5664,7 @@ function do_dblocks_migration($migration) {
       $a_table['fields']  = array();
       $a_table['fields']['value']      = array('type'    => 'bool',
                                                'value'   => NULL);
-      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP',
+      $a_table['fields']['date']       = array('type'    => 'timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP()',
                                                'value'   => NULL);
 
       $a_table['oldfields']  = array();
@@ -8462,6 +8462,12 @@ function migrateTablesFusionInventory($migration, $a_table) {
                                     'update'=> TRUE));
    }
 
+   foreach ($a_table['oldkeys'] as $field) {
+      $migration->dropKey($a_table['name'],
+                          $field);
+   }
+   $migration->migrationOneTable($a_table['name']);
+
    foreach ($a_table['oldfields'] as $field) {
       $migration->dropField($a_table['name'],
                             $field);
@@ -8482,12 +8488,6 @@ function migrateTablesFusionInventory($migration, $a_table) {
                            $field,
                            $data['type'],
                            array('value' => $data['value']));
-   }
-   $migration->migrationOneTable($a_table['name']);
-
-   foreach ($a_table['oldkeys'] as $field) {
-      $migration->dropKey($a_table['name'],
-                          $field);
    }
    $migration->migrationOneTable($a_table['name']);
 


### PR DESCRIPTION
  MariaDB 10.2 brings some changes:
- `SHOW CREATE TABLE` now gives an integer default value for integer fields,
- `SHOW CREATE TABLE` returns `current_timestamp()`ans no longer `CURRENT_TIMESTAMP`
- `longblob` can now take a default value; and GLPI Migration::addField() will set it to `null` (this cannot be overrided - see note on maria 10.2.1 https://mariadb.com/kb/en/library/blob-and-text-data-types/)
- it is not possible to drop a field that is part of an unicity index (https://mariadb.com/kb/en/library/alter-table/#drop-column)