### PR TITLE
Closes #2412 - tasks jobs log improvements

### DIFF
--- a/b/collect/index.php
+++ b/b/collect/index.php
@@ -87,10 +87,7 @@ switch (filter_input(INPUT_GET, "action")) {
                   }
 
                   // change status of state table row
-                  $pfTaskjobstate->changeStatus(
-                        $taskjobstate->fields['id'],
-                        PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA
-                  );
+                  $pfTaskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
 
                   $a_input = array(
                         'plugin_fusioninventory_taskjobstates_id'    => $taskjobstate->fields['id'],
@@ -177,8 +174,7 @@ switch (filter_input(INPUT_GET, "action")) {
             }
 
             // change status of state table row
-            $pfTaskjobstate->changeStatus($jobstate['id'],
-                       PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA);
+            $pfTaskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA);
 
             // add logs to job
             if (count($a_values)) {

--- a/b/deploy/index.php
+++ b/b/deploy/index.php
@@ -127,10 +127,7 @@ switch (filter_input(INPUT_GET, "action")) {
                         $order->associatedFiles->$hash = $associatedFiles;
                      }
                   }
-                  $taskjobstate->changeStatus(
-                     $taskjobstate->fields['id'] ,
-                     $taskjobstate::SERVER_HAS_SENT_DATA
-                  );
+                  $taskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
                }
 
                // return an empty dictionnary if there are no jobs.

--- a/b/esx/index.php
+++ b/b/esx/index.php
@@ -84,10 +84,7 @@ if (!empty($fi_machineid)) {
             foreach ($taskjobstates as $taskjobstate) {
                $order->jobs[] = $module->run($taskjobstate);
 
-               $taskjobstate->changeStatus(
-                  $taskjobstate->fields['id'] ,
-                  $taskjobstate::SERVER_HAS_SENT_DATA
-               );
+               $taskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
             }
 
             // return an empty dictionnary if there are no jobs.

--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -423,9 +423,9 @@ class PluginFusioninventoryCollect extends CommonDBTM {
 
       $c_input= array();
       $c_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
-      $c_input['state']                              = 0;
-      $c_input['plugin_fusioninventory_agents_id']   = 0;
-      $c_input['execution_id']                       = $task->fields['execution_id'];
+      $c_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
+      $c_input['plugin_fusioninventory_agents_id'] = 0;
+      $c_input['execution_id'] = $task->fields['execution_id'];
 
       $pfCollect = new PluginFusioninventoryCollect();
 
@@ -453,7 +453,7 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                              $pfCollect->fields['id']."'");
                      foreach ($a_registries as $data_r) {
                         $uniqid= uniqid();
-                        $c_input['state'] = 0;
+                        $c_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
                         $c_input['itemtype'] = 'PluginFusioninventoryCollect_Registry';
                         $c_input['items_id'] = $data_r['id'];
                         $c_input['date'] = date("Y-m-d H:i:s");
@@ -484,7 +484,7 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                              $pfCollect->fields['id']."'");
                      foreach ($a_wmies as $data_r) {
                         $uniqid= uniqid();
-                        $c_input['state'] = 0;
+                        $c_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
                         $c_input['itemtype'] = 'PluginFusioninventoryCollect_Wmi';
                         $c_input['items_id'] = $data_r['id'];
                         $c_input['date'] = date("Y-m-d H:i:s");
@@ -515,7 +515,7 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                              $pfCollect->fields['id']."'");
                      foreach ($a_files as $data_r) {
                         $uniqid= uniqid();
-                        $c_input['state'] = 0;
+                        $c_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
                         $c_input['itemtype'] = 'PluginFusioninventoryCollect_File';
                         $c_input['items_id'] = $data_r['id'];
                         $c_input['date'] = date("Y-m-d H:i:s");

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -77,7 +77,7 @@ class PluginFusioninventoryCommunicationNetworkDiscovery {
          $_SESSION['glpi_plugin_fusioninventory_processnumber'] = $a_CONTENT['PROCESSNUMBER'];
          if ($pfTaskjobstate->getFromDB($a_CONTENT['PROCESSNUMBER'])) {
             if ($pfTaskjobstate->fields['state'] != PluginFusioninventoryTaskjobstate::FINISHED) {
-               $pfTaskjobstate->changeStatus($a_CONTENT['PROCESSNUMBER'], 2);
+               $pfTaskjobstate->changeStatus($a_CONTENT['PROCESSNUMBER'], PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA);
                if ((!isset($a_CONTENT['AGENT']['START']))
                        AND (!isset($a_CONTENT['AGENT']['END']))) {
                   $nb_devices = 0;

--- a/inc/deploycommon.class.php
+++ b/inc/deploycommon.class.php
@@ -248,9 +248,9 @@ class PluginFusioninventoryDeployCommon extends PluginFusioninventoryCommunicati
 
       $c_input= [];
       $c_input['plugin_fusioninventory_taskjobs_id'] = $job->fields['id'];
-      $c_input['state']                              = 0;
-      $c_input['plugin_fusioninventory_agents_id']   = 0;
-      $c_input['execution_id']                       = $task->fields['execution_id'];
+      $c_input['state'] = 0;
+      $c_input['plugin_fusioninventory_agents_id'] = 0;
+      $c_input['execution_id'] = $task->fields['execution_id'];
 
       $package = new PluginFusioninventoryDeployPackage();
 
@@ -261,11 +261,11 @@ class PluginFusioninventoryDeployCommon extends PluginFusioninventoryCommunicati
             $uniqid = uniqid();
             $package->getFromDB($definition['PluginFusioninventoryDeployPackage']);
 
-            $c_input['state']    = 0;
+            $c_input['state'] = 0;
             $c_input['itemtype'] = 'PluginFusioninventoryDeployPackage';
             $c_input['items_id'] = $package->fields['id'];
-            $c_input['date']     = date("Y-m-d H:i:s");
-            $c_input['uniqid']   = $uniqid;
+            $c_input['date'] = date("Y-m-d H:i:s");
+            $c_input['uniqid'] = $uniqid;
 
             //get agent for this computer
             $agents_id = $agent->getAgentWithComputerid($computer_id);

--- a/inc/inventorycomputeresx.class.php
+++ b/inc/inventorycomputeresx.class.php
@@ -95,9 +95,9 @@ class PluginFusioninventoryInventoryComputerESX extends PluginFusioninventoryCom
       if (empty($agent_actionslist)) {
          $a_input= array();
          $a_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
-         $a_input['state']                              = 0;
+         $a_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
          $a_input['plugin_fusioninventory_agents_id']   = 0;
-         $a_input['uniqid']                             = $uniqid;
+         $a_input['uniqid'] = $uniqid;
          $a_input['execution_id']                       = $task->fields['execution_id'];
 
          foreach ($task_definitions as $task_definition) {
@@ -131,13 +131,13 @@ class PluginFusioninventoryInventoryComputerESX extends PluginFusioninventoryCom
                   foreach ($task_definition as $task_itemtype => $task_items_id) {
                      $a_input = array();
                      $a_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
-                     $a_input['state']                              = 0;
+                     $a_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
                      $a_input['plugin_fusioninventory_agents_id']   = $items_id;
-                     $a_input['itemtype']                           = $task_itemtype;
-                     $a_input['items_id']                           = $task_items_id;
-                     $a_input['uniqid']                             = $uniqid;
-                     $a_input['date']                               = date("Y-m-d H:i:s");
-                     $a_input['execution_id']                       = $task->fields['execution_id'];
+                     $a_input['itemtype'] = $task_itemtype;
+                     $a_input['items_id'] = $task_items_id;
+                     $a_input['uniqid'] = $uniqid;
+                     $a_input['date'] = date("Y-m-d H:i:s");
+                     $a_input['execution_id'] = $task->fields['execution_id'];
 
                      $jobstates_id = $jobstate->add($a_input);
                      //Add log of taskjob

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -939,9 +939,6 @@ class PluginFusioninventoryMenu extends CommonGLPI {
       // Number of computer inventories in last hour, 6 hours, 24 hours
       $dataInventory = PluginFusioninventoryInventoryComputerStat::getLastHours();
 
-      /*
-       * As of #2412 - temporarily removing this
-       *
       // Deploy
       $restrict_entity = getEntitiesRestrictRequest(" AND", 'glpi_plugin_fusioninventory_taskjobs');
       $query = "SELECT `plugin_fusioninventory_tasks_id`
@@ -955,7 +952,10 @@ class PluginFusioninventoryMenu extends CommonGLPI {
          $a_tasks[] = $data['plugin_fusioninventory_tasks_id'];
       }
       $pfTask = new PluginFusioninventoryTask();
-      $data = $pfTask->getJoblogs($a_tasks);
+      // Do not get logs with the jobs states, this to avoid long request time
+      // and this is not useful on the plugin home page
+      $data = $pfTask->getJoblogs($a_tasks, $with_logs=false);
+
 
       $dataDeploy = array();
       $dataDeploy[0] = array(
@@ -991,18 +991,13 @@ class PluginFusioninventoryMenu extends CommonGLPI {
       for ($k=0; $k<4; $k++) {
          $dataDeploy[$k]['key'] .= " : ".$dataDeploy[$k]['y'];
       }
-       */
 
 
       echo "<div class='fi_board'>";
       self::showChart('computers', $dataComputer);
       self::showChartBar('nbinventory', $dataInventory,
                          __('Number of computer inventories of last hours', 'fusioninventory'));
-      /*
-       * As of #2412 - temporarily removing this
-       *
       self::showChart('deploy', $dataDeploy, __('Deployment', 'fusioninventory'));
-      */
       self::showChart('snmp', $dataSNMP);
       self::showChart('ports', $dataPortL);
       self::showChart('portsconnected', $dataPortC);

--- a/inc/networkdiscovery.class.php
+++ b/inc/networkdiscovery.class.php
@@ -157,10 +157,10 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
                $a_input = array();
                $a_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
                $a_input['plugin_fusioninventory_agents_id'] = 0;
-               $a_input['state']        = 1;
-               $a_input['itemtype']     = 'PluginFusioninventoryIPRange';
-               $a_input['items_id']     = $iprange_id;
-               $a_input['uniqid']       = $uniqid;
+               $a_input['state'] = PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA;
+               $a_input['itemtype'] = 'PluginFusioninventoryIPRange';
+               $a_input['items_id'] = $iprange_id;
+               $a_input['uniqid'] = $uniqid;
                $a_input['execution_id'] = $task->fields['execution_id'];
 
                $Taskjobstates_id = $pfTaskjobstate->add($a_input);
@@ -191,7 +191,7 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
                   //Add jobstate and put status (waiting on server = 0)
                   $a_input = array();
                   $a_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
-                  $a_input['state'] = 0;
+                  $a_input['state'] = PluginFusioninventoryTaskjobstate::PREPARED;
                   $a_input['plugin_fusioninventory_agents_id'] = $agent_id;
                   $a_input['itemtype'] = 'PluginFusioninventoryIPRange';
                   $a_input['uniqid'] = $uniqid;
@@ -369,7 +369,7 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
       $sxml_rangeip->addAttribute('ENTITY', $pfIPRange->fields["entities_id"]);
 
       if ($changestate == '0') {
-         $pfTaskjobstate->changeStatus($pfTaskjobstate->fields['id'], 1);
+         $pfTaskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
          $pfTaskjoblog->addTaskjoblog($pfTaskjobstate->fields['id'],
                                  '0',
                                  'PluginFusioninventoryAgent',

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -605,6 +605,7 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
 
          $changestate = 0;
          $taskjobstatedatas = $jobstate->fields;
+         $pfTaskjobstate->fields['id'] = $taskjobstatedatas['id'];
          $sxml_device = $sxml_option->addChild('DEVICE');
 
          $a_extended = array('plugin_fusioninventory_configsecurities_id' => 0);
@@ -623,7 +624,7 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
          $sxml_device->addAttribute('AUTHSNMP_ID', $a_extended['plugin_fusioninventory_configsecurities_id']);
 
          if ($changestate == '0') {
-            $pfTaskjobstate->changeStatus($taskjobstatedatas['id'], 1);
+            $pfTaskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
             $pfTaskjoblog->addTaskjoblog($taskjobstatedatas['id'],
                '0',
                'PluginFusioninventoryAgent',

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -94,7 +94,6 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       $sopt['common'] = __('Task');
 
-
       $sopt[1]['table']          = $this->getTable();
       $sopt[1]['field']          = 'name';
       $sopt[1]['linkfield']      = 'name';
@@ -420,7 +419,6 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             continue;
          }
 
-
          //TODO: The following method (actually defined as member of taskjob) needs to be
          //initialized when getting the jobstate from DB (with a getfromDB hook for example)
          $jobstate->method = $result['job']['method'];
@@ -434,10 +432,12 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          if (!isset($jobstate['code'])) {
             $jobstate['code'] = PluginFusioninventoryTaskjobstate::CANCELLED;
          }
-         switch($jobstate['code']) {
+         switch ($jobstate['code']) {
+
             case PluginFusioninventoryTaskjobstate::IN_ERROR:
                $jobstate['jobstate']->fail($jobstate['reason']);
                break;
+
             default:
                $jobstate['jobstate']->cancel($jobstate['reason']);
                break;
@@ -586,7 +586,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
                   "    `itemtype` = '" . $item_type . "'",
                   "AND `items_id` = ".$item_id,
                   "AND `plugin_fusioninventory_taskjobs_id` = ". $job_id,
-                  "AND `state` not in ('" . implode( "','" , [
+                  "AND `state` not in ('" . implode( "','", [
                      PluginFusioninventoryTaskjobstate::FINISHED,
                      PluginFusioninventoryTaskjobstate::IN_ERROR,
                      PluginFusioninventoryTaskjobstate::POSTPONED,
@@ -636,7 +636,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
                   "    `itemtype` = '" . $item_type . "'",
                   "AND `items_id` = ".$item_id,
                   "AND `plugin_fusioninventory_taskjobs_id` = ". $job_id,
-                  "AND `state` not in ('" . implode( "','" , [
+                  "AND `state` not in ('" . implode( "','", [
                      PluginFusioninventoryTaskjobstate::FINISHED,
                      PluginFusioninventoryTaskjobstate::IN_ERROR,
                      PluginFusioninventoryTaskjobstate::CANCELLED
@@ -714,10 +714,10 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          // If this item doesn't exists, we continue to the next actor item.
          // TODO: remove this faulty actor from the list of job actor.
          if ($dbresult === false) {
-            continue ;
+            continue;
          }
 
-         switch($itemtype) {
+         switch ($itemtype) {
 
             case 'Computer':
                   $computers[$itemid] = 1;
@@ -757,11 +757,14 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
              * TODO: The following should be replaced with Dynamic groups
              */
             case 'PluginFusioninventoryAgent':
-               switch($itemid) {
+               switch ($itemid) {
+
                   case "dynamic":
                      break;
+
                   case "dynamic-same-subnet":
                      break;
+
                   default:
                      $agents[$itemid] = 1;
                      break;
@@ -833,8 +836,6 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
    function cleanTasksAndJobs($interval) {
       global $DB;
 
-
-      $pfTaskjob      = new PluginFusioninventoryTaskjob();
       $pfTaskjobstate = new PluginFusioninventoryTaskjobstate();
       $pfTask         = new PluginFusioninventoryTask();
 
@@ -924,7 +925,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
    **/
    function forceRunning() {
       $methods = [];
-      foreach( PluginFusioninventoryStaticmisc::getmethods() as $method) {
+      foreach (PluginFusioninventoryStaticmisc::getmethods() as $method) {
          $methods[] = $method['method'];
       }
       $this->prepareTaskjobs($methods, $this->getID());
@@ -955,7 +956,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       // The concerned tasks list
       if (is_array($task_ids) AND count($task_ids) > 0) {
-         $tasks_list = "AND task.`id` IN ('".implode("', '",$task_ids)."')";
+         $tasks_list = "AND task.`id` IN ('".implode("', '", $task_ids)."')";
       } else {
          // Not task identifiers provided
          return ['tasks' => $logs, 'agents' => $agents];
@@ -968,7 +969,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-tasks",
-         "Get tasks jobs log, tasks list: ". implode(",",$task_ids));
+         "Get tasks jobs log, tasks list: ". implode(",", $task_ids));
 
       $prepare_chrono = [
          "start" => microtime(true),
@@ -1080,7 +1081,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             }
 
             $target_id = $item_type . "_" . $item_id;
-            if($item_name == "") {
+            if ($item_name == "") {
                $item = new $item_type;
                if ($item->getFromDB($item_id)) {
                   $item_name = $item->fields['name'];
@@ -1144,7 +1145,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       $tasks_list1 = '';
       if (is_array($task_ids) AND count($task_ids) > 0) {
-         $tasks_list1 = "`plugin_fusioninventory_tasks_id` IN ('".implode("', '",$task_ids)."')";
+         $tasks_list1 = "`plugin_fusioninventory_tasks_id` IN ('".implode("', '", $task_ids)."')";
       }
       $taskjobs = $pftaskjob->find($tasks_list1);
       $counter_agents = [];
@@ -1171,183 +1172,183 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
            "pluginFusioninventory-tasks",
            $q_task_job_state);
 
-        // Parse the query result to update the data to return
-        $count_results = 0;
-        while ($result = $q_task_job_state['result']->fetch_assoc()) {
-           PluginFusioninventoryToolbox::logIfExtradebug(
-              "pluginFusioninventory-tasks",
-              "Result: " . print_r($result, true));
+         // Parse the query result to update the data to return
+         $count_results = 0;
+         while ($result = $q_task_job_state['result']->fetch_assoc()) {
+            PluginFusioninventoryToolbox::logIfExtradebug(
+               "pluginFusioninventory-tasks",
+               "Result: " . print_r($result, true));
 
-           // ***** create a unique key ***** //
+            // ***** create a unique key ***** //
 
-           $key_runs = $result['agent.id']."+".$result['items_id']."+".$result['itemtype'];
-           if (!isset($counter_agents[$key_runs])) {
+            $key_runs = $result['agent.id']."+".$result['items_id']."+".$result['itemtype'];
+            if (!isset($counter_agents[$key_runs])) {
                $counter_agents[$key_runs] = 0;
-           }
-           $counter_agents[$key_runs]++;
-           if ($counter_agents[$key_runs] > $max_runs) {
+            }
+            $counter_agents[$key_runs]++;
+            if ($counter_agents[$key_runs] > $max_runs) {
                continue;
-           }
+            }
 
-           // We need to check if the results are consistent with the view's structure gathered
-           // by the first query
-           $task_id = $taskjob['plugin_fusioninventory_tasks_id'];
-           if (!isset($logs[$task_id])) {
-              continue;
-           }
-           $job_id = $taskjob['id'];
-           $jobs   = &$logs[$task_id]['jobs'];
-           if (!isset($jobs[$job_id])) {
-              continue;
-           }
-           $target_id = $result['itemtype'].'_'.$result['items_id'];
-           $targets   = &$jobs[$job_id]['targets'];
-           if (!isset($targets[$target_id])) {
-              continue;
-           }
+            // We need to check if the results are consistent with the view's structure gathered
+            // by the first query
+            $task_id = $taskjob['plugin_fusioninventory_tasks_id'];
+            if (!isset($logs[$task_id])) {
+               continue;
+            }
+            $job_id = $taskjob['id'];
+            $jobs   = &$logs[$task_id]['jobs'];
+            if (!isset($jobs[$job_id])) {
+               continue;
+            }
+            $target_id = $result['itemtype'].'_'.$result['items_id'];
+            $targets   = &$jobs[$job_id]['targets'];
+            if (!isset($targets[$target_id])) {
+               continue;
+            }
 
-           $count_results += 1;
+            $count_results += 1;
 
-           $counters = &$targets[$target_id]['counters'];
-           $agent_id = $result['agent.id'];
-           // This to be updated if needed!
-           $agents[$agent_id] = $result['agent.name'];
+            $counters = &$targets[$target_id]['counters'];
+            $agent_id = $result['agent.id'];
+            // This to be updated if needed!
+            $agents[$agent_id] = $result['agent.name'];
 
-           if (!isset($targets[$target_id]['agents'][$agent_id])) {
-              $targets[$target_id]['agents'][$agent_id] = [];
-           }
-           $agent_state = '';
-           $run_id = $result['id'];
+            if (!isset($targets[$target_id]['agents'][$agent_id])) {
+               $targets[$target_id]['agents'][$agent_id] = [];
+            }
+            $agent_state = '';
+            $run_id = $result['id'];
 
-           // Update counters
+            // Update counters
 
-           switch ($result['state']) {
-              case PluginFusioninventoryTaskjobstate::CANCELLED :
-                 // We put this agent in the cancelled counter
-                 // if it does not have any other job states.
-                 if (!isset($counters['agents_prepared'][$agent_id])
-                    && !isset($counters['agents_running'][$agent_id])) {
-                    $counters['agents_cancelled'][$agent_id] = $run_id;
-                    $agent_state = 'cancelled';
-                 }
-                 break;
+            switch ($result['state']) {
+               case PluginFusioninventoryTaskjobstate::CANCELLED :
+                  // We put this agent in the cancelled counter
+                  // if it does not have any other job states.
+                  if (!isset($counters['agents_prepared'][$agent_id])
+                     && !isset($counters['agents_running'][$agent_id])) {
+                     $counters['agents_cancelled'][$agent_id] = $run_id;
+                     $agent_state = 'cancelled';
+                  }
+                  break;
 
-              case PluginFusioninventoryTaskjobstate::PREPARED :
-                 // We put this agent in the prepared counter
-                 // if it has not yet completed any job.
-                 $counters['agents_prepared'][$agent_id] = $run_id;
-                 $agent_state = 'prepared';
+               case PluginFusioninventoryTaskjobstate::PREPARED :
+                  // We put this agent in the prepared counter
+                  // if it has not yet completed any job.
+                  $counters['agents_prepared'][$agent_id] = $run_id;
+                  $agent_state = 'prepared';
 
-                 // drop running counter for agent if preparation more recent
-                 if (isset($counters['agents_running'][$agent_id])
-                    && $counters['agents_running'][$agent_id] < $run_id) {
-                    unset($counters['agents_running'][$agent_id]);
-                 }
+                  // drop running counter for agent if preparation more recent
+                  if (isset($counters['agents_running'][$agent_id])
+                     && $counters['agents_running'][$agent_id] < $run_id) {
+                     unset($counters['agents_running'][$agent_id]);
+                  }
 
-                 // drop cancelled counter for agent if preparation more recent
-                 if (isset($counters['agents_cancelled'][$agent_id])
-                    && $counters['agents_cancelled'][$agent_id] < $run_id) {
-                    unset($counters['agents_cancelled'][$agent_id]);
-                 }
-                 break;
+                  // drop cancelled counter for agent if preparation more recent
+                  if (isset($counters['agents_cancelled'][$agent_id])
+                     && $counters['agents_cancelled'][$agent_id] < $run_id) {
+                     unset($counters['agents_cancelled'][$agent_id]);
+                  }
+                  break;
 
-              case PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA :
-              case PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA :
-                 // This agent is running so it must not be in any other counter
-                 // remove older counters
-                 foreach ($agent_state_types as $type) {
-                    if (isset($counters[$type][$agent_id])
-                       && $counters[$type][$agent_id] < $run_id) {
-                       unset($counters[$type][$agent_id]);
-                    }
-                 }
-                 $counters['agents_running'][$agent_id] = $run_id;
-                 $agent_state = 'running';
-                 break;
+               case PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA :
+               case PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA :
+                  // This agent is running so it must not be in any other counter
+                  // remove older counters
+                  foreach ($agent_state_types as $type) {
+                     if (isset($counters[$type][$agent_id])
+                        && $counters[$type][$agent_id] < $run_id) {
+                        unset($counters[$type][$agent_id]);
+                     }
+                  }
+                  $counters['agents_running'][$agent_id] = $run_id;
+                  $agent_state = 'running';
+                  break;
 
-              case PluginFusioninventoryTaskjobstate::IN_ERROR :
-                 // drop older success
-                 if (isset($counters['agents_success'][$agent_id])
-                    && $counters['agents_success'][$agent_id] < $run_id) {
-                    unset($counters['agents_success'][$agent_id]);
-                 }
+               case PluginFusioninventoryTaskjobstate::IN_ERROR :
+                  // drop older success
+                  if (isset($counters['agents_success'][$agent_id])
+                     && $counters['agents_success'][$agent_id] < $run_id) {
+                     unset($counters['agents_success'][$agent_id]);
+                  }
 
-                 // if we don't have success run (more recent due to previous test)
-                 // so we are really in error
-                 if (!isset($counters['agents_success'][$agent_id])) {
-                    $counters['agents_error'][$agent_id] = $run_id;
-                    unset($counters['agents_notdone'][$agent_id]);
-                 }
+                  // if we don't have success run (more recent due to previous test)
+                  // so we are really in error
+                  if (!isset($counters['agents_success'][$agent_id])) {
+                     $counters['agents_error'][$agent_id] = $run_id;
+                     unset($counters['agents_notdone'][$agent_id]);
+                  }
 
-                 $agent_state = 'error';
-                 break;
+                  $agent_state = 'error';
+                  break;
 
-              case PluginFusioninventoryTaskjobstate::FINISHED :
-                 // drop older error
-                 if (isset($counters['agents_error'][$agent_id])
-                    && $counters['agents_error'][$agent_id] < $run_id) {
-                    unset($counters['agents_error'][$agent_id]);
-                 }
+               case PluginFusioninventoryTaskjobstate::FINISHED :
+                  // drop older error
+                  if (isset($counters['agents_error'][$agent_id])
+                     && $counters['agents_error'][$agent_id] < $run_id) {
+                     unset($counters['agents_error'][$agent_id]);
+                  }
 
-                 // if we don't have error run (more recent due to previous test)
-                 // so we are really in success
-                 if (!isset($counters['agents_error'][$agent_id])) {
-                    $counters['agents_success'][$agent_id] = $run_id;
-                    unset($counters['agents_notdone'][$agent_id]);
-                 }
+                  // if we don't have error run (more recent due to previous test)
+                  // so we are really in success
+                  if (!isset($counters['agents_error'][$agent_id])) {
+                     $counters['agents_success'][$agent_id] = $run_id;
+                     unset($counters['agents_notdone'][$agent_id]);
+                  }
 
-                 $agent_state = 'success';
-                 break;
-           }
-           if (!isset($counters['agents_error'][$agent_id])
-              && !isset($counters['agents_success'][$agent_id])) {
-              $counters['agents_notdone'][$agent_id] = $run_id;
-           }
-           if (isset($counters['agents_running'][$agent_id])
-              || isset($counters['agents_prepared'][$agent_id])) {
-              unset($counters['agents_cancelled'][$agent_id]);
-           }
-           if ($with_logs) {
-              $query = $q_job_state_last_log['query'];
-              $query = str_replace('RUN.ID', $run_id, $query);
-              $q_job_state_last_log['real_query'] = $query;
-              $q_job_state_last_log['result'] = $DB->query($query);
+                  $agent_state = 'success';
+                  break;
+            }
+            if (!isset($counters['agents_error'][$agent_id])
+               && !isset($counters['agents_success'][$agent_id])) {
+               $counters['agents_notdone'][$agent_id] = $run_id;
+            }
+            if (isset($counters['agents_running'][$agent_id])
+               || isset($counters['agents_prepared'][$agent_id])) {
+               unset($counters['agents_cancelled'][$agent_id]);
+            }
+            if ($with_logs) {
+               $query = $q_job_state_last_log['query'];
+               $query = str_replace('RUN.ID', $run_id, $query);
+               $q_job_state_last_log['real_query'] = $query;
+               $q_job_state_last_log['result'] = $DB->query($query);
 
-              $q_job_state_last_log['end'] = microtime(true);
-              $q_job_state_last_log['duration'] = self::formatChrono($q_job_state_last_log);
-              PluginFusioninventoryToolbox::logIfExtradebug(
-                 "pluginFusioninventory-tasks",
-                 "Log query: " . print_r($q_job_state_last_log, true));
-              while ($log_result = $q_job_state_last_log['result']->fetch_assoc()) {
-                 PluginFusioninventoryToolbox::logIfExtradebug(
-                    "pluginFusioninventory-tasks",
-                    "Log: " . print_r($log_result, true));
-                 $targets[$target_id]['agents'][$agent_id][] = [
-                    'agent_id'      => $agent_id,
-                    'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
-                    'numstate'      => $result['state'],
-                    'state'         => $agent_state,
-                    'jobstate_id'   => $run_id,
-                    'last_log_id'   => $log_result['log.last_id'],
-                    'last_log_date' => $log_result['log.last_date'],
-                    'timestamp'     => $log_result['log.last_timestamp'],
-                    'last_log'      => $log_result['log.last_comment']
-                 ];
-              }
-           } else {
-              $targets[$target_id]['agents'][$agent_id][] = [
-                 'agent_id'      => $agent_id,
-                 'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
-                 'numstate'      => $result['state'],
-                 'state'         => $agent_state,
-                 'jobstate_id'   => $run_id,
-  //               'last_log_id'   => $result['log.last_id'],
-  //               'last_log_date' => $result['log.last_date'],
-  //               'timestamp'     => $result['log.last_timestamp'],
-  //               'last_log'      => $result['log.last_comment']
-              ];
-           }
-        }
+               $q_job_state_last_log['end'] = microtime(true);
+               $q_job_state_last_log['duration'] = self::formatChrono($q_job_state_last_log);
+               PluginFusioninventoryToolbox::logIfExtradebug(
+                  "pluginFusioninventory-tasks",
+                  "Log query: " . print_r($q_job_state_last_log, true));
+               while ($log_result = $q_job_state_last_log['result']->fetch_assoc()) {
+                  PluginFusioninventoryToolbox::logIfExtradebug(
+                     "pluginFusioninventory-tasks",
+                     "Log: " . print_r($log_result, true));
+                  $targets[$target_id]['agents'][$agent_id][] = [
+                     'agent_id'      => $agent_id,
+                     'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
+                     'numstate'      => $result['state'],
+                     'state'         => $agent_state,
+                     'jobstate_id'   => $run_id,
+                     'last_log_id'   => $log_result['log.last_id'],
+                     'last_log_date' => $log_result['log.last_date'],
+                     'timestamp'     => $log_result['log.last_timestamp'],
+                     'last_log'      => $log_result['log.last_comment']
+                  ];
+               }
+            } else {
+               $targets[$target_id]['agents'][$agent_id][] = [
+                  'agent_id'      => $agent_id,
+                  'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
+                  'numstate'      => $result['state'],
+                  'state'         => $agent_state,
+                  'jobstate_id'   => $run_id,
+                  //'last_log_id'   => $result['log.last_id'],
+                  //'last_log_date' => $result['log.last_date'],
+                  //'timestamp'     => $result['log.last_timestamp'],
+                  //'last_log'      => $result['log.last_comment']
+               ];
+            }
+         }
       }
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-tasks",
@@ -1477,11 +1478,11 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       if (isset( $filter['is_running'])
               AND is_bool($filter['is_running'])) {
          //TODO: get running taskjobs
-//         if ($filter['is_running']) {
-//            $where[] = "( task.`execution_id` != taskjob.`execution_id` )";
-//         } else {
-//            $where[] = "( task.`execution_id` = taskjob.`execution_id` )";
-//         }
+         //if ($filter['is_running']) {
+         //   $where[] = "( task.`execution_id` != taskjob.`execution_id` )";
+         //} else {
+         //   $where[] = "( task.`execution_id` = taskjob.`execution_id` )";
+         //}
          // add taskjobs table JOIN statement if not already set
          if (!isset( $leftjoin['taskjobs'])) {
                $leftjoin_bak = $leftjoin;
@@ -1561,13 +1562,13 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       }
 
       //TODO: Filter by list of IDs
-      if (isset($filter['by_ids'])
-              AND is_bool($filter['by_entities'])) {
-      }
+      //if (isset($filter['by_ids'])
+      //        AND is_bool($filter['by_entities'])) {
+      //}
 
       // Filter by entity
       if (isset($filter['by_entities'])
-	      AND (bool)$filter['by_entities']) {
+              AND (bool)$filter['by_entities']) {
          $where[] = getEntitiesRestrictRequest("", 'task');
       }
 
@@ -1783,53 +1784,61 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
          if (count($task['jobs']) == 0) {
             echo NL;
-         } else foreach ($task['jobs'] as $job_id => $job) {
-            echo $job['name'].SEP;
-            echo $job['method'].SEP;
+         } else {
+            foreach ($task['jobs'] as $job_id => $job) {
+               echo $job['name'].SEP;
+               echo $job['method'].SEP;
 
-            if (count($job['targets']) == 0) {
-               echo NL;
-            } else foreach ($job['targets'] as $target_id => $target) {
-               echo $target['name'].SEP;
-
-               if (count($target['agents']) == 0) {
+               if (count($job['targets']) == 0) {
                   echo NL;
-               } else foreach ($target['agents'] as $agent_id => $agent) {
-                  $agent_obj->getFromDB($agent_id);
-                  echo $agent_obj->getName().SEP;
-                  $computer->getFromDB($agent_obj->fields['computers_id']);
-                  echo $computer->getname().SEP;
+               } else {
+                  foreach ($job['targets'] as $target_id => $target) {
+                     echo $target['name'].SEP;
 
-                  $log_cpt = 0;
-                  if (count($agent) == 0) {
-                     echo NL;
-                  } else foreach ($agent as $exec_id => $exec) {
-                     echo $exec['last_log_date'].SEP;
-                     echo $exec['state'].SEP;
-                     echo $exec['last_log'].NL;
-                     $log_cpt++;
+                     if (count($target['agents']) == 0) {
+                        echo NL;
+                     } else {
+                        foreach ($target['agents'] as $agent_id => $agent) {
+                           $agent_obj->getFromDB($agent_id);
+                           echo $agent_obj->getName().SEP;
+                           $computer->getFromDB($agent_obj->fields['computers_id']);
+                           echo $computer->getname().SEP;
 
-                     if ($includeoldjobs != -1 AND $log_cpt >= $includeoldjobs) {
-                        break;
+                           $log_cpt = 0;
+                           if (count($agent) == 0) {
+                              echo NL;
+                           } else {
+                              foreach ($agent as $exec_id => $exec) {
+                                 echo $exec['last_log_date'].SEP;
+                                 echo $exec['state'].SEP;
+                                 echo $exec['last_log'].NL;
+                                 $log_cpt++;
+
+                                 if ($includeoldjobs != -1 AND $log_cpt >= $includeoldjobs) {
+                                    break;
+                                 }
+
+                                 if (!$last($agent, $exec_id)) {
+                                    echo SEP.SEP.SEP.SEP.SEP.SEP;
+                                 }
+                              }
+                           }
+
+                           if (!$last($target['agents'], $agent_id)) {
+                              echo SEP.SEP.SEP.SEP;
+                           }
+                        }
                      }
 
-                     if (!$last($agent, $exec_id)) {
-                        echo SEP.SEP.SEP.SEP.SEP.SEP;
+                     if (!$last($job['targets'], $target_id)) {
+                        echo SEP.SEP.SEP;
                      }
-                  }
-
-                  if (!$last($target['agents'], $agent_id)) {
-                     echo SEP.SEP.SEP.SEP;
                   }
                }
 
-               if (!$last($job['targets'], $target_id)) {
-                  echo SEP.SEP.SEP;
+               if (!$last($task['jobs'], $job_id)) {
+                  echo SEP;
                }
-            }
-
-            if (!$last($task['jobs'], $job_id)) {
-               echo SEP;
             }
          }
       }
@@ -1874,11 +1883,11 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
          case "transfert":
             Dropdown::show('Entity');
-            echo Html::submit(_x('button','Post'), array('name' => 'massiveaction'));
+            echo Html::submit(_x('button', 'Post'), array('name' => 'massiveaction'));
             return true;
 
          case "duplicate":
-            echo Html::submit(_x('button','Post'), array('name' => 'massiveaction'));
+            echo Html::submit(_x('button', 'Post'), array('name' => 'massiveaction'));
             return true;
 
          case 'target_task' :
@@ -1923,7 +1932,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
             echo "<tr>";
             echo "<td colspan='2' align='center'>";
-            echo Html::submit(_x('button','Post'), array('name' => 'massiveaction'));
+            echo Html::submit(_x('button', 'Post'), array('name' => 'massiveaction'));
             echo "</td>";
             echo "</tr>";
             echo "</table>";
@@ -1960,7 +1969,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
             echo "<tr>";
             echo "<td colspan='2' align='center'>";
-            echo Html::submit(_x('button','Post'), array('name' => 'massiveaction'));
+            echo Html::submit(_x('button', 'Post'), array('name' => 'massiveaction'));
             echo "</td>";
             echo "</tr>";
             echo "</table>";
@@ -1988,18 +1997,18 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       switch ($ma->getAction()) {
 
          case "duplicate":
-         foreach ($ids as $key) {
-            if ($pfTask->getFromDB($key)) {
-               if ($pfTask->duplicate($pfTask->getID())) {
-                  //set action massive ok for this item
-                  $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
-               } else {
-                  // KO
-                  $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+            foreach ($ids as $key) {
+               if ($pfTask->getFromDB($key)) {
+                  if ($pfTask->duplicate($pfTask->getID())) {
+                     //set action massive ok for this item
+                     $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                  } else {
+                     // KO
+                     $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                  }
                }
             }
-         }
-         break;
+            break;
 
          case "transfert" :
             foreach ($ids as $key) {

--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -453,12 +453,17 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
     *
     * @global object $DB
     * @param array $methods
+    * @param string $task_id; the concerned task
     * @return true
     */
-   function prepareTaskjobs($methods = [], $tasks_id = false) {
+   function prepareTaskjobs($methods = [], $task_id = false) {
       global $DB;
 
       $now = new DateTime();
+
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-scheduler",
+         "Prepare tasks jobs, task id: ". $task_id);
 
       //Get all active timeslots
       $timeslot  = new PluginFusioninventoryTimeslot();
@@ -474,8 +479,8 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       // limit preparation to a specific tasks_id
       $sql_task_id = "";
-      if ($tasks_id) {
-         $sql_task_id = "AND `task`.`id` = $tasks_id";
+      if ($task_id) {
+         $sql_task_id = "AND `task`.`id` = $task_id";
       }
 
       $query = implode( " \n", [
@@ -674,6 +679,10 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
                         ]
                      );
                      $joblog->add($log);
+                     PluginFusioninventoryToolbox::logIfExtradebug(
+                        "pluginFusioninventory-scheduler",
+                        "- prepared: ". print_r($log, true));
+
                   }
                }
             }
@@ -816,6 +825,8 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       return true;
    }
 
+
+
    /**
    * Get all on demand tasks to clean
    * @param $interval number of days to look for successful tasks
@@ -871,6 +882,8 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       return $index;
    }
 
+
+
    /**
     * Give cron information
     *
@@ -907,6 +920,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
    }
 
 
+
    /**
    * Force running the current task
    **/
@@ -923,14 +937,23 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
    /**
     * Get logs of job
     *
+    * Returns a map array containing: ['tasks' => $logs, 'agents' => $agents]
+    * - tasks: is a map containing the objects of a task
+    * - agents: is a list of the agents involved in the tasks jobs
+    *
     * @global object $DB
     * @param array $task_ids list of tasks id
+    * @param bool $with_logs default to true to get jobs execution logs with the jobs states
+    * @param bool $only_active, set to true to include only active tasks
     * @return array
     */
-   function getJoblogs($task_ids = []) {
+   function getJoblogs($task_ids = [], $with_logs=true, $only_active=false) {
       global $DB, $CFG_GLPI;
 
-      $debug_mode = ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE);
+      // Results grouped by tasks > jobs > jobstates
+      $logs = [];
+      // Agents concerned by the logs
+      $agents = [];
 
       $query_where = ["WHERE 1"];
 
@@ -942,47 +965,44 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          $query_where[] = "AND task.`id` IN (" . implode(",",$task_ids) . ")";
       }
 
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "Get tasks jobs log, tasks list: ". implode(",",$task_ids));
+
+      $prepare_chrono = [
+         "start" => microtime(true),
+         "end"   => 0
+      ];
       // quickly filter empty WHERE entry
       $query_where = array_filter($query_where);
 
-      $query_fields = [
-         ['task.id'     , 'task.`id`'],
-         ['task.name'   , 'task.`name`'],
-         ['job.id'      , 'job.`id`'],
-         ['job.name'    , 'job.`name`'],
-         ['job.method'  , 'job.`method`'],
-         ['job.targets' , 'job.`targets`'],
-      ];
-
-      $fieldmap = [];
-      foreach ($query_fields as $index => $key) {
-         $fieldmap[$key[0]]=$index;
-      }
-
-      $query_select = [];
-      foreach ($query_fields as $index => $key) {
-         $query_select[] = $key[1] . " AS '" . $key[0] . "'";
-      }
-
-      $query_joins         = [];
-      $query_joins['task'] = "
-         INNER JOIN `glpi_plugin_fusioninventory_tasks` as task
-            ON job.`plugin_fusioninventory_tasks_id` = task.`id`
-            AND task.`is_active` = 1";
-
+      $active_task = $only_active ? "AND `is_active`='1'" : "";
       $data_structure = [
          'query' => "SELECT
-                    ".implode(",\n", $query_select)."
-                    FROM `glpi_plugin_fusioninventory_taskjobs` as job
-                    ".implode("\n", $query_joins)."
-                    ".implode("\n", $query_where),
-         'result' => null
+            `job`.`id` as 'job.id',
+            `job`.`name` as 'job.name',
+            `job`.`method` as 'job.method',
+            `job`.`targets` as 'job.targets',
+            `task`.`id` as 'task.id',
+            `task`.`name` as 'task.name'
+            FROM `glpi_plugin_fusioninventory_taskjobs` as job
+            INNER JOIN `glpi_plugin_fusioninventory_tasks` as task
+              ON job.`plugin_fusioninventory_tasks_id` = task.`id` $active_task "
+            .implode("\n", $query_where),
+         'result' => null,
+         "start" => microtime(true),
+         "end"   => 0
       ];
 
       $data_structure['result'] = $DB->query($data_structure['query']);
-
-      //Results grouped by tasks > jobs > jobstates
-      $logs          = [];
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "Preparing query: " . print_r($data_structure, true));
+      if ($data_structure['result']->num_rows <= 0) {
+         // Not useful to go further, we will not have any result to send!
+         // Perharps the required tasks are not even active ;)
+         return ['tasks' => $logs, 'agents' => $agents];
+      }
 
       //Target cache (used to speed up data formatting)
       $targets_cache = [];
@@ -991,12 +1011,24 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          $expanded = $_SESSION['plugin_fusioninventory_tasks_expanded'];
       }
 
-      while ($result = $data_structure['result']->fetch_row()) {
-         $task_id = $result[$fieldmap['task.id']];
-         if (!array_key_exists($task_id, $logs)) {
+      $agent_state_types = [
+         'agents_prepared',
+         'agents_cancelled',
+         'agents_running',
+         'agents_success',
+         'agents_error',
+         'agents_notdone'
+      ];
+      while ($result = $data_structure['result']->fetch_assoc()) {
+         PluginFusioninventoryToolbox::logIfExtradebug(
+            "pluginFusioninventory-tasks",
+            "Job: " . print_r($result, true));
+
+         $task_id = $result['task.id'];
+         if (! array_key_exists($task_id, $logs)) {
             $logs[$task_id] = [
-               'task_name' => $result[$fieldmap['task.name']],
-               'task_id'   => $result[$fieldmap['task.id']],
+               'task_name' => $result['task.name'],
+               'task_id'   => $result['task.id'],
                'expanded'  => false,
                'jobs'      => []
             ];
@@ -1006,28 +1038,20 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             $logs[$task_id]['expanded'] = $expanded[$task_id];
          }
 
-         $job_id = $result[$fieldmap['job.id']];
+         $job_id = $result['job.id'];
          $jobs_handle = &$logs[$task_id]['jobs'];
          if (!array_key_exists($job_id, $jobs_handle)) {
             $jobs_handle[$job_id] = [
-               'name'    => $result[ $fieldmap['job.name']],
-               'id'      => $result[ $fieldmap['job.id']],
-               'method'  => $result[ $fieldmap['job.method']],
+               'name'    => $result['job.name'],
+               'id'      => $result['job.id'],
+               'method'  => $result['job.method'],
                'targets' => []
             ];
          }
-         $targets = importArrayFromDB($result[$fieldmap['job.targets']]);
+         $targets = importArrayFromDB($result['job.targets']);
          $targets_handle = &$jobs_handle[$job_id]['targets'];
-         $agent_state_types = [
-            'agents_prepared',
-            'agents_cancelled',
-            'agents_running',
-            'agents_success',
-            'agents_error',
-            'agents_notdone'
-         ];
 
-         if ($result[$fieldmap['job.method']] == 'networkinventory') {
+         if ($result['job.method'] == 'networkinventory') {
             $pfNetworkinventory = new PluginFusioninventoryNetworkinventory();
             foreach ($targets as $keyt=>$target) {
                $item_type = key($target);
@@ -1042,6 +1066,10 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          }
 
          foreach ($targets as $target) {
+            PluginFusioninventoryToolbox::logIfExtradebug(
+               "pluginFusioninventory-tasks",
+               "- target: " . print_r($target, true));
+
             $item_type = key($target);
             $item_id   = current($target);
             $item_name = "";
@@ -1071,6 +1099,279 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          }
       }
 
+      $prepare_chrono['end'] = microtime(true);
+      $prepare_chrono['duration'] = self::formatChrono($prepare_chrono);
+
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "Prepared: " . print_r($logs, true));
+
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         $prepare_chrono);
+
+      // The concerned tasks list
+      $tasks_list = implode("', '",$task_ids);
+
+      // How many run log must we provide ?
+      $max_runs = 1;
+      if (isset($_SESSION['glpi_plugin_fusioninventory']['includeoldjobs'])) {
+         if ($_SESSION['glpi_plugin_fusioninventory']['includeoldjobs'] >= 1) {
+            $max_runs = $_SESSION['glpi_plugin_fusioninventory']['includeoldjobs'];
+         }
+      }
+
+      /*
+       * The first query will get all the tasks jobs and their current state. This query is run on the DB
+       * to get a first list that is enough as result if $with_logs is not required. A joint is used to limit the
+       * job states used to the maximum count of execution required.
+       *
+       * The second query is a template to get the log of a specific job execution. This query is run for each job
+       * state to get the execution log.
+       */
+      $q_task_job_state = [
+         'query' => "SELECT 
+               `job`.`id` as 'job.id',
+               `job`.`name` as 'job.name',
+               `job`.`method` as 'job.method',
+               `job`.`targets` as 'job.targets',
+               `run`.`id` as 'run.id',
+               `run`.`itemtype` as 'run.itemtype',
+               `run`.`items_id` as 'run.items_id',
+               `run`.`state` as 'run.state',
+               `run`.`plugin_fusioninventory_agents_id` as 'run.agent_id',
+               `agent`.`id` as 'agent.id',
+               `agent`.`computers_id` as 'agent.computers_id',
+               `agent`.`name` as 'agent.name',
+               `task`.`id` as 'task.id',
+               `task`.`entities_id` as 'task.entities_id',
+               `task`.`name` as 'task.name'
+            FROM `glpi_plugin_fusioninventory_taskjobs` as job
+            INNER JOIN `glpi_plugin_fusioninventory_tasks` AS task
+              ON task.`id` = job.`plugin_fusioninventory_tasks_id`
+            INNER JOIN (
+              SELECT 
+                `me`.id, 
+                `me`.`plugin_fusioninventory_taskjobs_id`, 
+                `me`.`itemtype`, 
+                `me`.`items_id`, 
+                `me`.`state`, 
+                `me`.`plugin_fusioninventory_agents_id` 
+              FROM `glpi_plugin_fusioninventory_taskjobstates` as me
+              INNER JOIN `glpi_plugin_fusioninventory_taskjobs`
+              ON `plugin_fusioninventory_taskjobs_id`=`glpi_plugin_fusioninventory_taskjobs`.`id` 
+              ORDER BY `me`.`id` DESC 
+              LIMIT $max_runs
+            ) AS run
+              ON job.`id` = run.`plugin_fusioninventory_taskjobs_id`
+            INNER JOIN `glpi_plugin_fusioninventory_agents` AS agent
+              ON agent.`id` = run.`plugin_fusioninventory_agents_id`
+            WHERE job.`plugin_fusioninventory_tasks_id` IN ('$tasks_list') 
+            GROUP BY
+               run.`plugin_fusioninventory_agents_id`,
+               run.`plugin_fusioninventory_taskjobs_id`,
+               run.`itemtype`,
+               run.`items_id`, 
+               run.`id`
+            ORDER BY job.`id` DESC",
+         'result' => null,
+         "start" => microtime(true),
+         "end"   => 0
+      ];
+      $q_job_state_last_log = [
+         'query' => "SELECT 
+             `log`.`id` as 'log.last_id',
+             `log`.`date` as 'log.last_date',
+             `log`.`comment` as 'log.last_comment',
+             UNIX_TIMESTAMP(log.`date`) as 'log.last_timestamp'
+             FROM `glpi_plugin_fusioninventory_taskjoblogs` AS log
+             WHERE log.`plugin_fusioninventory_taskjobstates_id` = 'RUN.ID' 
+             ORDER BY log.`id` DESC",
+         'result' => null,
+         "start" => microtime(true),
+         "end"   => 0
+      ];
+
+      // Execute query to get all jobs states - log the query result
+      $q_task_job_state['result'] = $DB->query($q_task_job_state['query']);
+      $q_task_job_state['end'] = microtime(true);
+      $q_task_job_state['duration'] = self::formatChrono($q_task_job_state);
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         $q_task_job_state);
+
+      // Parse the query result to update the data to return
+      $count_results = 0;
+      while ($result = $q_task_job_state['result']->fetch_assoc()) {
+         PluginFusioninventoryToolbox::logIfExtradebug(
+            "pluginFusioninventory-tasks",
+            "Result: " . print_r($result, true));
+
+         // We need to check if the results are consistent with the view's structure gathered
+         // by the first query
+         $task_id = $result['task.id'];
+         if (!isset($logs[$task_id])) {
+            continue;
+         }
+         $job_id = $result['job.id'];
+         $jobs   = &$logs[$task_id]['jobs'];
+         if (!isset($jobs[$job_id])) {
+            continue;
+         }
+         $target_id = $result['run.itemtype'].'_'.$result['run.items_id'];
+         $targets   = &$jobs[$job_id]['targets'];
+         if (!isset($targets[$target_id])) {
+            continue;
+         }
+
+         $count_results += 1;
+
+         $counters = &$targets[$target_id]['counters'];
+         $agent_id = $result['agent.id'];
+         // This to be updated if needed!
+         $agents[$agent_id] = $result['agent.name'];
+
+         if (!isset($targets[$target_id]['agents'][$agent_id])) {
+            $targets[$target_id]['agents'][$agent_id] = [];
+         }
+         $agent_state = '';
+         $run_id = $result['run.id'];
+
+         // Update counters
+         switch ($result['run.state']) {
+            case PluginFusioninventoryTaskjobstate::CANCELLED :
+               // We put this agent in the cancelled counter
+               // if it does not have any other job states.
+               if (!isset($counters['agents_prepared'][$agent_id])
+                  && !isset($counters['agents_running'][$agent_id])) {
+                  $counters['agents_cancelled'][$agent_id] = $run_id;
+                  $agent_state = 'cancelled';
+               }
+               break;
+
+            case PluginFusioninventoryTaskjobstate::PREPARED :
+               // We put this agent in the prepared counter
+               // if it has not yet completed any job.
+               $counters['agents_prepared'][$agent_id] = $run_id;
+               $agent_state = 'prepared';
+
+               // drop running counter for agent if preparation more recent
+               if (isset($counters['agents_running'][$agent_id])
+                  && $counters['agents_running'][$agent_id] < $run_id) {
+                  unset($counters['agents_running'][$agent_id]);
+               }
+
+               // drop cancelled counter for agent if preparation more recent
+               if (isset($counters['agents_cancelled'][$agent_id])
+                  && $counters['agents_cancelled'][$agent_id] < $run_id) {
+                  unset($counters['agents_cancelled'][$agent_id]);
+               }
+               break;
+
+            case PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA :
+            case PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA :
+               // This agent is running so it must not be in any other counter
+               // remove older counters
+               foreach ($agent_state_types as $type) {
+                  if (isset($counters[$type][$agent_id])
+                     && $counters[$type][$agent_id] < $run_id) {
+                     unset($counters[$type][$agent_id]);
+                  }
+               }
+               $agent_state = 'running';
+               break;
+
+            case PluginFusioninventoryTaskjobstate::IN_ERROR :
+               // drop older success
+               if (isset($counters['agents_success'][$agent_id])
+                  && $counters['agents_success'][$agent_id] < $run_id) {
+                  unset($counters['agents_success'][$agent_id]);
+               }
+
+               // if we don't have success run (more recent due to previous test)
+               // so we are really in error
+               if (!isset($counters['agents_success'][$agent_id])) {
+                  $counters['agents_error'][$agent_id] = $run_id;
+                  unset($counters['agents_notdone'][$agent_id]);
+               }
+
+               $agent_state = 'error';
+               break;
+
+            case PluginFusioninventoryTaskjobstate::FINISHED :
+               // drop older error
+               if (isset($counters['agents_error'][$agent_id])
+                  && $counters['agents_error'][$agent_id] < $run_id) {
+                  unset($counters['agents_error'][$agent_id]);
+               }
+
+               // if we don't have error run (more recent due to previous test)
+               // so we are really in success
+               if (!isset($counters['agents_error'][$agent_id])) {
+                  $counters['agents_success'][$agent_id] = $run_id;
+                  unset($counters['agents_notdone'][$agent_id]);
+               }
+
+               $agent_state = 'success';
+               break;
+         }
+         if (!isset($counters['agents_error'][$agent_id])
+            && !isset($counters['agents_success'][$agent_id])) {
+            $counters['agents_notdone'][$agent_id] = $run_id;
+         }
+         if (isset($counters['agents_running'][$agent_id])
+            || isset($counters['agents_prepared'][$agent_id])) {
+            unset($counters['agents_cancelled'][$agent_id]);
+         }
+
+         if ($with_logs) {
+            $query = $q_job_state_last_log['query'];
+            $query = str_replace('RUN.ID', $run_id, $query);
+            $q_job_state_last_log['real_query'] = $query;
+            $q_job_state_last_log['result'] = $DB->query($query);
+
+            $q_job_state_last_log['end'] = microtime(true);
+            $q_job_state_last_log['duration'] = self::formatChrono($q_job_state_last_log);
+            PluginFusioninventoryToolbox::logIfExtradebug(
+               "pluginFusioninventory-tasks",
+               "Log query: " . print_r($q_job_state_last_log, true));
+            while ($log_result = $q_job_state_last_log['result']->fetch_assoc()) {
+//               PluginFusioninventoryToolbox::logIfExtradebug(
+//                  "pluginFusioninventory-tasks",
+//                  "Log: " . print_r($log_result, true));
+               $targets[$target_id]['agents'][$agent_id][] = [
+                  'agent_id'      => $agent_id,
+                  'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
+                  'numstate'      => $result['run.state'],
+                  'state'         => $agent_state,
+                  'jobstate_id'   => $run_id,
+                  'last_log_id'   => $log_result['log.last_id'],
+                  'last_log_date' => $log_result['log.last_date'],
+                  'timestamp'     => $log_result['log.last_timestamp'],
+                  'last_log'      => $log_result['log.last_comment']
+               ];
+            }
+         } else {
+            $targets[$target_id]['agents'][$agent_id][] = [
+               'agent_id'      => $agent_id,
+               'link'          => $CFG_GLPI['root_doc']."/front/computer.form.php?id=" .$result['agent.computers_id'],
+               'numstate'      => $result['run.state'],
+               'state'         => $agent_state,
+               'jobstate_id'   => $run_id,
+//               'last_log_id'   => $result['log.last_id'],
+//               'last_log_date' => $result['log.last_date'],
+//               'timestamp'     => $result['log.last_timestamp'],
+//               'last_log'      => $result['log.last_comment']
+            ];
+         }
+      }
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "Got $count_results results");
+
+      return ['tasks' => $logs, 'agents' => $agents];
+
+      /*
       // Query fields mapping used to easily select fields by name
       $query_fields = [
          ['task.id',            'task.`id`'],
@@ -1158,6 +1459,11 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
 
       $queries = [];
 
+//      PluginFusioninventoryToolbox::logIfExtradebug(
+//         "pluginFusioninventory-tasks",
+//         "- joins: " . print_r($query_joins, true)
+//      );
+
       // Get jobstates for agents limited by fi_include_jobs
       $queries['limited_runs'] = [
          'query' => "SELECT
@@ -1176,6 +1482,11 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       ];
       ksort($queries);
 
+//      PluginFusioninventoryToolbox::logIfExtradebug(
+//         "pluginFusioninventory-tasks",
+//         "- queries: " . print_r($queries, true)
+//      );
+
       //init mysql variables
       $DB->query("SET @num := 0");
       $DB->query("SET @agent_id := 0");
@@ -1188,10 +1499,6 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          $queries[$query_name]['result'] = $DB->query($contents['query']);
 
          $query_chrono['end'] = microtime(true);
-         // For debug only
-         //if ($debug_mode) {
-         //   file_put_contents("/tmp/glpi_".$query_name.".sql",$contents['query']);
-         //}
       }
 
       $agents        = [];
@@ -1340,28 +1647,35 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       $format_chrono['end'] = microtime(true);
       if ($debug_mode) {
 
-         /**
-          * Display tmp log
-          *
-          * @param array $log
-          * @return string
-          */
          function tmp_display_log($log) {
             return "ID:". $log['task_id'] . "(".$log['task_name'].")";
          }
-         if (PluginFusioninventoryConfig::isExtradebugActive()) {
-            Toolbox::logDebug(
-               [
-                  "tasks"               => implode(',',array_map('tmp_display_log', $logs)),
-                  "row count"           => count($logs),
-                  "Joblogs Query"       => self::formatChrono($query_chrono),
-                  "Format logs results" => self::formatChrono($format_chrono),
-               ]
-            );
-         }
+         PluginFusioninventoryToolbox::logIfExtradebug(
+            "pluginFusioninventory-tasks",
+            [
+               "tasks"               => implode(',',array_map('tmp_display_log', $logs)),
+               "row count"           => count($logs),
+               "Joblogs Query"       => self::formatChrono($query_chrono),
+               "Format logs results" => self::formatChrono($format_chrono),
+            ]
+         );
+
+//         if (PluginFusioninventoryConfig::isExtradebugActive()) {
+//            Toolbox::logDebug(
+//               [
+//                  "tasks"               => implode(',',array_map('tmp_display_log', $logs)),
+//                  "row count"           => count($logs),
+//                  "Joblogs Query"       => self::formatChrono($query_chrono),
+//                  "Format logs results" => self::formatChrono($format_chrono),
+//               ]
+//            );
+//         }
       }
       return ['tasks' => $logs, 'agents' => $agents];
+      */
    }
+
+
 
    /**
     * Ajax called to get job logs
@@ -1370,12 +1684,13 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
     *                          - task_id (mandatory), the current task id
     *                          - includeoldjobs: the value of "include old jobs" list
     *                          - refresh: the value of "refresh interval" list
-    *                          - display: true for direct diplay of html or false for return
+    *                          - display: true for direct display of json result else returns a json encoded string
     *
     * @return depends on @param $options['display'].
+    * @return string, empty if json results are displayed
     */
    function ajaxGetJobLogs($options = []) {
-      if (!empty($options['task_id'])) {
+      if (! empty($options['task_id'])) {
          if (is_array($options['task_id'])) {
             $task_ids = $options['task_id'];
          } else {
@@ -1396,13 +1711,24 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       //unlock session since access checks have been done (to avoid lock another page)
       session_write_close();
 
-      $logs = $this->getJoblogs($task_ids);
+      $logs = $this->getJoblogs($task_ids, true, false);
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "ajaxGetJobLogs, agents: " . count($logs['agents']));
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "ajaxGetJobLogs, agents: " . count($logs['tasks']));
+
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-tasks",
+         "ajaxGetJobLogs: " . print_r($logs, true));
       $out = json_encode($logs);
       if (isset($options['display'])
           AND !$options['display']) {
          return $out;
       } else {
          echo $out;
+         return '';
       }
    }
 
@@ -1413,9 +1739,10 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
     *
     * @global object $DB
     * @param integer $tasks_id if 0, no restriction so get all
+    * @param bool $only_active, set to true to include only active tasks
     * @return object
     */
-   function getTasksPlanned($tasks_id=0) {
+   function getTasksPlanned($tasks_id=0, $only_active=true) {
       global $DB;
 
       $where = '';
@@ -1425,6 +1752,8 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             LIMIT 1 ";
       }
 
+      // Include tasks that are not active
+      $active_task = $only_active ? "AND `is_active`='1'" : "";
       $query = "SELECT * FROM `glpi_plugin_fusioninventory_tasks` as task
          WHERE execution_id =
             (SELECT execution_id FROM glpi_plugin_fusioninventory_taskjobs as taskjob
@@ -1432,7 +1761,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
                ORDER BY execution_id DESC
                LIMIT 1
             )
-            AND `is_active`='1'
+            $active_task
             AND `periodicity_count` > 0
             AND `periodicity_type` != '0' ".$where;
       return $DB->query($query);
@@ -1668,6 +1997,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
    }
 
 
+
    /**
     * Export a list of jobs in CSV format
     *
@@ -1690,7 +2020,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       ];
       $params = array_merge($default_params, $params);
 
-      $includeoldjobs    = $_SESSION['glpi_plugin_fusioninventory']['includeoldjobs'];
+      $includeoldjobs = $_SESSION['glpi_plugin_fusioninventory']['includeoldjobs'];
       $agent_state_types = ['prepared', 'cancelled', 'running', 'success', 'error' ];
       if (isset($params['agent_state_types'])) {
          $agent_state_types = $params['agent_state_types'];
@@ -1708,8 +2038,8 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       }
 
       $params['display'] = false;
-      $pfTask            = new PluginFusioninventoryTask();
-      $data              = json_decode($pfTask->ajaxGetJobLogs($params), true);
+      $pfTask = new PluginFusioninventoryTask();
+      $data = json_decode($pfTask->ajaxGetJobLogs($params), true);
 
       //clean line with state_types with unwanted states
       foreach ($data['tasks'] as $task_id => &$task) {
@@ -1728,7 +2058,6 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
             }
          }
       }
-
       // clean old temporary variables
       unset($task, $job, $target, $agent);
 
@@ -1830,6 +2159,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       // force exit to prevent further display
       exit;
    }
+
 
    /**
     * Get the massive actions for this object

--- a/inc/taskjobstate.class.php
+++ b/inc/taskjobstate.class.php
@@ -180,7 +180,7 @@ class PluginFusioninventoryTaskjobstate extends CommonDBTM {
    * @return string
    *
    **/
-   function stateTaskjob ($taskjobs_id, $width=930, $return='html', $style='') {
+   function stateTaskjob($taskjobs_id, $width=930, $return='html', $style='') {
       global $DB;
 
       $state = [0 => 0, 1 => 0, 2 => 0, 3 => 0];
@@ -333,14 +333,13 @@ class PluginFusioninventoryTaskjobstate extends CommonDBTM {
    /**
     * Change the state
     *
-    * @todo There is no need to pass $id since we should use this method with
-    *       an instantiated object
-    *
-    * @param integer $id id of the taskjobstate
     * @param integer $state state to set
     */
-   function changeStatus($id, $state) {
-      $this->update(['id' => $id, 'state' => $state]);
+   function changeStatus($state) {
+      $this->update(['id' => $this->getID(), 'state' => $state]);
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-jobs",
+         "Job execution ". $this->getID() ." changed state: $state");
    }
 
 
@@ -478,6 +477,10 @@ class PluginFusioninventoryTaskjobstate extends CommonDBTM {
       }
 
       $this->update($input);
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-jobs",
+         "Job execution $taskjobstates_id changed state: " . $input['state']);
+
       $log_input['plugin_fusioninventory_taskjobstates_id'] = $taskjobstates_id;
       $log_input['items_id'] = $items_id;
       $log_input['itemtype'] = $itemtype;
@@ -550,6 +553,9 @@ class PluginFusioninventoryTaskjobstate extends CommonDBTM {
          'id'    => $this->fields['id'],
          'state' => $jobstate_state
       ]);
+      PluginFusioninventoryToolbox::logIfExtradebug(
+         "pluginFusioninventory-jobs",
+         "Job execution (update_state)".$this->fields['id']." changed state: $jobstate_state");
    }
 
    private function processPostonedJob($type) {

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -61,12 +61,11 @@ class PluginFusioninventoryToolbox {
     * @param string $message
     */
    static function logIfExtradebug($file, $message) {
-      $config = new PluginFusioninventoryConfig();
-      if ($config->getValue('extradebug')) {
+      if (PluginFusioninventoryConfig::isExtradebugActive()) {
          if (is_array($message)) {
-            $message = print_r($message, TRUE);
+            $message = print_r($message, true);
          }
-         Toolbox::logInFile($file, $message);
+         Toolbox::logInFile($file, $message . "\n", true);
       }
    }
 

--- a/inc/wakeonlan.class.php
+++ b/inc/wakeonlan.class.php
@@ -206,7 +206,7 @@ class PluginFusioninventoryWakeonlan extends PluginFusioninventoryCommunication 
       if (count($a_agentList) == '0') {
          $a_input = array();
          $a_input['plugin_fusioninventory_taskjobs_id'] = $taskjobs_id;
-         $a_input['state'] = 1;
+         $a_input['state'] = PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA;
          $a_input['plugin_fusioninventory_agents_id'] = 0;
          $a_input['itemtype'] = 'Computer';
          $a_input['items_id'] = 0;
@@ -214,7 +214,7 @@ class PluginFusioninventoryWakeonlan extends PluginFusioninventoryCommunication 
          $Taskjobstates_id = $pfTaskjobstate->add($a_input);
             //Add log of taskjob
             $a_input['plugin_fusioninventory_taskjobstates_id'] = $Taskjobstates_id;
-            $a_input['state'] = 7;
+            $a_input['state'] = PluginFusioninventoryTaskjoblog::TASK_PREPARED;
             $a_input['date'] = date("Y-m-d H:i:s");
             $pfTaskjoblog->add($a_input);
 
@@ -240,7 +240,7 @@ class PluginFusioninventoryWakeonlan extends PluginFusioninventoryCommunication 
                 $Taskjobstates_id = $pfTaskjobstate->add($a_input);
                   //Add log of taskjob
                   $a_input['plugin_fusioninventory_taskjobstates_id'] = $Taskjobstates_id;
-                  $a_input['state'] = 7;
+                  $a_input['state'] = PluginFusioninventoryTaskjoblog::TASK_PREPARED;
                   $a_input['date'] = date("Y-m-d H:i:s");
                   $pfTaskjoblog->add($a_input);
                   unset($a_input['state']);
@@ -276,6 +276,7 @@ class PluginFusioninventoryWakeonlan extends PluginFusioninventoryCommunication 
       $changestate = 0;
 //      foreach ($taskjobstates as $jobstate) {
          $data = $jobstate->fields;
+         $pfTaskjobstate->fields['id'] = $data['id'];
          $a_networkPort = $NetworkPort->find("`itemtype`='Computer' AND `items_id`='".
                                                 $data['items_id']."' ");
          $computerip = 0;
@@ -288,7 +289,7 @@ class PluginFusioninventoryWakeonlan extends PluginFusioninventoryCommunication 
                   //$sxml_param->addAttribute('IP', $datanetwork['ip']);
 
                   if ($changestate == '0') {
-                     $pfTaskjobstate->changeStatus($data['id'], 1);
+                     $pfTaskjobstate->changeStatus(PluginFusioninventoryTaskjobstate::SERVER_HAS_SENT_DATA);
                      $pfTaskjoblog->addTaskjoblog($data['id'],
                                              '0',
                                              'Computer',

--- a/phpunit/2_Integration/Tasks/CronTaskTest.php
+++ b/phpunit/2_Integration/Tasks/CronTaskTest.php
@@ -59,6 +59,10 @@ class CronTaskTest extends RestoreDatabase_TestCase {
       $pfDeployGroup_Dynamicdata = new PluginFusioninventoryDeployGroup_Dynamicdata();
       $pfEntity        = new PluginFusioninventoryEntity();
 
+      // Activate the extra debug log
+      $pfConfig = new PluginFusioninventoryConfig();
+      $pfConfig->updateValue('extradebug', '1');
+
 
       $input = array(
           'id'             => 1,
@@ -203,12 +207,54 @@ class CronTaskTest extends RestoreDatabase_TestCase {
 
       $pfTask = new PluginFusioninventoryTask();
 
-      $data = $pfTask->getJoblogs(array(1));
+      // All tasks (active or not) and get logs
+      // Default parameters
+      $data = $pfTask->getJoblogs([1]);
 
+      // If agents exist in the output, this means that some jobs are existing and they have some logs
       $ref = array(
           1 => 'portdavid',
           2 => 'computer2',
           3 => 'computer3'
+      );
+
+      $this->assertEquals($ref, $data['agents']);
+
+      foreach ($data['tasks'] as $task_id => &$task) {
+         foreach ($task['jobs'] as $job_id => &$job) {
+            foreach ($job['targets'] as $target_id => &$target) {
+               foreach ($target['agents'] as $agent_id => &$agent) {
+                  $logs = $data['tasks'][$task_id]['jobs'][$job_id]['targets'][$target_id]['agents'][$agent_id];
+                  $this->assertEquals(1, count($logs));
+                  /* We get something like:
+                     [agent_id] => 1
+                     [link] => ./vendor/bin/phpunit/front/computer.form.php?id=1
+                     [numstate] => 0
+                     [state] => prepared
+                     [jobstate_id] => 1
+                     [last_log_id] => 1
+                     [last_log_date] => 2018-01-20 12:44:06
+                     [timestamp] => 1516448646
+                     [last_log] =>
+                   */
+                  foreach ($logs as $log_id => &$log) {
+                     $this->assertEquals($log['agent_id'], $agent_id);
+                     $this->assertEquals($log['state'], "prepared");
+                     $this->assertEquals($log['last_log'], "");
+                  }
+               }
+            }
+         }
+      }
+
+      // All tasks (active or not) and get logs
+      $data = $pfTask->getJoblogs([1], true, false);
+
+      // If agents exist in the output, this means that some jobs are existing and they have some logs
+      $ref = array(
+         1 => 'portdavid',
+         2 => 'computer2',
+         3 => 'computer3'
       );
 
       $this->assertEquals($ref, $data['agents']);
@@ -249,7 +295,8 @@ class CronTaskTest extends RestoreDatabase_TestCase {
 
       $pfTask = new PluginFusioninventoryTask();
 
-      $data = $pfTask->getJoblogs(array(1));
+      // All tasks (active or not) and get logs
+      $data = $pfTask->getJoblogs([1], true, false);
 
       $ref = array(
           1 => 'portdavid',
@@ -282,7 +329,8 @@ class CronTaskTest extends RestoreDatabase_TestCase {
 
       $pfTask = new PluginFusioninventoryTask();
 
-      $data = $pfTask->getJoblogs(array(1));
+      // All tasks (active or not) and get logs
+      $data = $pfTask->getJoblogs([1], true, false);
 
       $ref = array(
           1 => 'portdavid',
@@ -320,7 +368,8 @@ class CronTaskTest extends RestoreDatabase_TestCase {
 
       PluginFusioninventoryTask::cronTaskscheduler();
 
-      $data = $pfTask->getJoblogs(array(1));
+      // Only for active tasks and with logs
+      $data = $pfTask->getJoblogs([1], true, true);
 
       $ref = array();
 
@@ -329,6 +378,44 @@ class CronTaskTest extends RestoreDatabase_TestCase {
       $ref_prepared = array();
 
       $this->assertEquals($ref_prepared, $data['tasks']);
+   }
+
+
+
+   public function prepareTaskNoLogs() {
+      global $DB;
+
+      // Verify prepare a deploy task
+      $DB->connect();
+
+      PluginFusioninventoryTask::cronTaskscheduler();
+
+      $pfTask = new PluginFusioninventoryTask();
+
+      // All tasks (active or not) and no logs
+      $data = $pfTask->getJoblogs([1], false, false);
+
+      // If agents exist in the output, this means that some jobs are existing and they have some logs
+      $ref = array(
+         1 => 'portdavid',
+         2 => 'computer2',
+         3 => 'computer3'
+      );
+
+      $this->assertEquals($ref, $data['agents']);
+
+      foreach ($data['tasks'] as $task_id => &$task) {
+         foreach ($task['jobs'] as $job_id => &$job) {
+            foreach ($job['targets'] as $target_id => &$target) {
+               foreach ($target['agents'] as $agent_id => &$agent) {
+                  $logs = $data['tasks'][$task_id]['jobs'][$job_id]['targets'][$target_id]['agents'][$agent_id];
+                  // No logs
+                  $this->assertEquals(0, count($logs));
+               }
+            }
+         }
+      }
+
    }
 
 


### PR DESCRIPTION
Improve the huge query used to get the tasks jobs log (closes #2412)
Add some extra-debug logs for this process
Allow to get information withou or without execution result log
Allow to view graph/log for non active tasks (closes #2314)