### PR TITLE
Closes #2412 and #2314 - improve query on plugin home page

### DIFF
--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -940,7 +940,9 @@ class PluginFusioninventoryMenu extends CommonGLPI {
          $a_tasks[] = $data['plugin_fusioninventory_tasks_id'];
       }
       $pfTask = new PluginFusioninventoryTask();
-      $data = $pfTask->getJoblogs($a_tasks);
+      // Do not get logs with the jobs states, this to avoid long request time
+      // and this is not useful on the plugin home page
+      $data = $pfTask->getJoblogs($a_tasks, $with_logs=false);
 
       $dataDeploy = [];
       $dataDeploy[0] = [

--- a/inc/toolbox.class.php
+++ b/inc/toolbox.class.php
@@ -62,12 +62,11 @@ class PluginFusioninventoryToolbox {
     * @param string $message
     */
    static function logIfExtradebug($file, $message) {
-      $config = new PluginFusioninventoryConfig();
-      if ($config->getValue('extradebug')) {
+      if (PluginFusioninventoryConfig::isExtradebugActive()) {
          if (is_array($message)) {
             $message = print_r($message, true);
          }
-         Toolbox::logInFile($file, $message);
+         Toolbox::logInFile($file, $message . "\n", true);
       }
    }
 


### PR DESCRIPTION
Improve the huge query used to get the tasks jobs log (closes #2412)
Add some extra-debug logs for this process
Allow to get information with or without execution result log
Allow to view graph/log for non active tasks (closes #2314)