### PR TITLE
Fix dropdown values to link an agent to a computer: was sending a wrong entity ID

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -407,7 +407,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
                "<img src='".$CFG_GLPI['root_doc']."/pics/delete.png' /></a>";
       } else {
          Computer_Item::dropdownConnect("Computer", "Computer", 'computers_id',
-                                        $_SESSION['glpiactive_entity']);
+                                        $this->fields['entities_id']);
       }
       echo "</td>";
       echo "<td>".__('Token')."&nbsp:</td>";


### PR DESCRIPTION
The dropdown link an agent to a computer returns bad values because entity passed to the method is the current entity, instead of the agent's entity