### PR TITLE
Fix stanalone FIRMWARES and SIMCARDS

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -82,6 +82,21 @@ class PluginFusioninventoryFormatconvert {
 
       $PLUGIN_FUSIONINVENTORY_XML = $xml;
       $datainventory = json_decode(json_encode((array)$xml), TRUE);
+
+      //TODO: factorize this code with older one (need to find a suitable solution for all)
+      //Fix multivalued/standalone
+      $multi = [
+         'FIRMWARES',
+         'SIMCARDS'
+      ];
+      foreach ($multi as $elt) {
+         if (count($xml->xpath('/REQUEST/CONTENT/DEVICE/' . $elt)) == 1) {
+            $tmp = $datainventory['CONTENT']['DEVICE'][$elt];
+            unset($datainventory['CONTENT']['DEVICE'][$elt]);
+            $datainventory['CONTENT']['DEVICE'][$elt] = [$tmp];
+         }
+      }
+
       if (isset($datainventory['CONTENT']['ENVS'])) {
          unset($datainventory['CONTENT']['ENVS']);
       }
@@ -2004,13 +2019,6 @@ class PluginFusioninventoryFormatconvert {
    */
    function simcardTransformation($array, &$a_inventory) {
       if (isset($array['SIMCARDS'])) {
-         //If there's only one entry
-         if (!isset($array['SIMCARDS'][0])) {
-            $tmp                 = $array['SIMCARDS'];
-            $array               = [];
-            //We're waiting for an array of simcards
-            $array['SIMCARDS'][0] = $tmp;
-         }
          $mapping = [
             'ICCID'         => 'serial',
             'MANUFACTURER'  => 'manufacturers_id',

--- a/phpunit/2_Integration/ComputerDeviceSimcardTest.php
+++ b/phpunit/2_Integration/ComputerDeviceSimcardTest.php
@@ -163,13 +163,15 @@ class ComputerDeviceSimcardTest extends RestoreDatabase_TestCase {
       $formatConvert = new PluginFusioninventoryFormatconvert();
 
       $input = [
-            'SIMCARDS' => [
-            'COUNTRY'       => 'France',
-            'ICCID'         => "11124406000051565111",
-            'IMSI'          => "204043721717241",
-            'OPERATOR_CODE' => '208.10',
-            'OPERATOR_NAME' => 'SFR',
-            'STATE'         => 'SIM1 - Ready (PIN checking disabled)',
+         'SIMCARDS' => [
+            0  => [
+               'COUNTRY'       => 'France',
+               'ICCID'         => "11124406000051565111",
+               'IMSI'          => "204043721717241",
+               'OPERATOR_CODE' => '208.10',
+               'OPERATOR_NAME' => 'SFR',
+               'STATE'         => 'SIM1 - Ready (PIN checking disabled)'
+            ]
          ]
       ];
       $a_inventory = [];


### PR DESCRIPTION
Import is OK when there are several `FIRMWARES` tags in the XML, but it fails when there is only one.
Same issue exists form SIMCARDS, I've factorized.

Problem is encode/decode XML to convert it to an array. In the first case, we get:
```
$array [
   0 => [
      'name' => '...',
      'version' => '...'
   ],
   1 => [
      'name' => '...',
      'version' => '...'
   ]
```
But with the second case:
```
   'name' => '...',
   'version' => '...'
```