### PR TITLE
Do not add entries in the log at asset creation

### DIFF
--- a/inc/communicationnetworkinventory.class.php
+++ b/inc/communicationnetworkinventory.class.php
@@ -245,9 +245,10 @@ class PluginFusioninventoryCommunicationNetworkInventory {
     * @param string $itemtype
     * @param integer $items_id
     * @param array $a_inventory
+    * @param boolean $no_history notice if changes must be logged or not
     * @return string errors or empty string
     */
-   function importDevice($itemtype, $items_id, $a_inventory) {
+   function importDevice($itemtype, $items_id, $a_inventory, $no_history) {
       global $PLUGIN_FUSIONINVENTORY_XML;
 
       PluginFusioninventoryCommunication::addLog(
@@ -287,14 +288,14 @@ class PluginFusioninventoryCommunicationNetworkInventory {
             $pfiPrinterLib = new PluginFusioninventoryInventoryPrinterLib();
             $a_inventory['PluginFusioninventoryPrinter']['serialized_inventory'] =
                         Toolbox::addslashes_deep($serialized);
-            $pfiPrinterLib->updatePrinter($a_inventory, $items_id);
+            $pfiPrinterLib->updatePrinter($a_inventory, $items_id, $no_history);
             break;
 
          case 'NetworkEquipment':
             $pfiNetworkEquipmentLib = new PluginFusioninventoryInventoryNetworkEquipmentLib();
             $a_inventory['PluginFusioninventoryNetworkEquipment']['serialized_inventory'] =
                         Toolbox::addslashes_deep($serialized);
-            $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $items_id);
+            $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $items_id, $no_history);
             break;
 
          default:
@@ -443,6 +444,8 @@ class PluginFusioninventoryCommunicationNetworkInventory {
     */
    function rulepassed($items_id, $itemtype) {
 
+      $no_history = false;
+
       PluginFusioninventoryLogger::logIfExtradebug(
          "pluginFusioninventory-rules",
          "Rule passed : ".$items_id.", ".$itemtype."\n"
@@ -477,8 +480,9 @@ class PluginFusioninventoryCommunicationNetworkInventory {
          $_SESSION["plugin_fusioninventory_entity"] = $input['entities_id'];
 
          //Add defaut status if there's one defined in the configuration
-         $input    = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('snmp', $input);
-         $items_id = $class->add($input);
+         $input      = PluginFusioninventoryToolbox::addDefaultStateIfNeeded('snmp', $input);
+         $items_id   = $class->add($input);
+         $no_history = true;
          if (isset($_SESSION['plugin_fusioninventory_rules_id'])) {
             $pfRulematchedlog = new PluginFusioninventoryRulematchedlog();
             $inputrulelog = array();
@@ -523,7 +527,7 @@ class PluginFusioninventoryCommunicationNetworkInventory {
          $_SESSION['plugin_fusinvsnmp_taskjoblog']['comment'] =
                '[==detail==] Update '.$class->getTypeName().' [['.$itemtype.'::'.$items_id.']]';
          $this->addtaskjoblog();
-         $errors .= $this->importDevice($itemtype, $items_id, $a_inventory);
+         $errors .= $this->importDevice($itemtype, $items_id, $a_inventory, $no_history);
       }
       return $errors;
    }

--- a/inc/inventorycommon.class.php
+++ b/inc/inventorycommon.class.php
@@ -103,7 +103,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
                'is_dynamic'   => 1,
                'entities_id'  => $_SESSION['glpiactive_entity']
             ];
-            $relation->add($input, [], $no_history);
+            $relation->add($input, [], !$no_history);
          }
       }
    }
@@ -147,7 +147,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
             $a_port['instantiation_type'] = 'NetworkPortEthernet';
             $a_port['items_id']    = $items_id;
             $a_port['itemtype']    = $itemtype;
-            $networkports_id = $networkPort->add($a_port, [], $no_history);
+            $networkports_id = $networkPort->add($a_port, [], !$no_history);
             unset($a_port['id']);
             $a_pfnetworkport_DB = current($pfNetworkPort->find(
                     "`networkports_id`='".$networkports_id."'", '', 1));
@@ -223,7 +223,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
          $input['is_dynamic']    = 1;
          $input['entities_id']   = $_SESSION['glpiactive_entity'];
          if ($relation->isNewItem()) {
-            $relations_id = $relation->add($input, [], $no_history);
+            $relations_id = $relation->add($input, [], !$no_history);
          } else {
             $input['id']  = $relation->getID();
             $relations_id = $relation->update($input);

--- a/inc/inventorycommon.class.php
+++ b/inc/inventorycommon.class.php
@@ -63,7 +63,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
     *
     * @return void
     */
-   function importFirmwares($itemtype, $a_inventory, $items_id) {
+   function importFirmwares($itemtype, $a_inventory, $items_id, $no_history = false) {
       if (!isset($a_inventory['firmwares']) || !count($a_inventory['firmwares'])) {
          return;
       }
@@ -103,7 +103,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
                'is_dynamic'   => 1,
                'entities_id'  => $_SESSION['glpiactive_entity']
             ];
-            $relation->add($input);
+            $relation->add($input, [], $no_history);
          }
       }
    }
@@ -114,7 +114,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
     * @param array $a_inventory
     * @param integer $items_id
     */
-   function importPorts($itemtype, $a_inventory, $items_id) {
+   function importPorts($itemtype, $a_inventory, $items_id, $no_history = false) {
 
       $networkPort     = new NetworkPort();
       $pfNetworkPort   = new PluginFusioninventoryNetworkPort();
@@ -145,9 +145,9 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
          if ($new) {
             // Add port
             $a_port['instantiation_type'] = 'NetworkPortEthernet';
-            $a_port['items_id'] = $items_id;
-            $a_port['itemtype'] = $itemtype;
-            $networkports_id = $networkPort->add($a_port);
+            $a_port['items_id']    = $items_id;
+            $a_port['itemtype']    = $itemtype;
+            $networkports_id = $networkPort->add($a_port, [], $no_history);
             unset($a_port['id']);
             $a_pfnetworkport_DB = current($pfNetworkPort->find(
                     "`networkports_id`='".$networkports_id."'", '', 1));
@@ -185,7 +185,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
     *
     * @return void
     */
-   function importSimcards($itemtype, $a_inventory, $items_id) {
+   function importSimcards($itemtype, $a_inventory, $items_id, $no_history = false) {
       if (!isset($a_inventory['simcards']) || !count($a_inventory['simcards'])) {
          return;
       }
@@ -218,12 +218,12 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
          //Check if there's already a connection between the simcard and an asset
          $relation->getFromDBByCrit($input);
 
-         $input['itemtype']    = $itemtype;
-         $input['items_id']    = $items_id;
-         $input['is_dynamic']  = 1;
-         $input['entities_id'] = $_SESSION['glpiactive_entity'];
+         $input['itemtype']      = $itemtype;
+         $input['items_id']      = $items_id;
+         $input['is_dynamic']    = 1;
+         $input['entities_id']   = $_SESSION['glpiactive_entity'];
          if ($relation->isNewItem()) {
-            $relations_id = $relation->add($input);
+            $relations_id = $relation->add($input, [], $no_history);
          } else {
             $input['id']  = $relation->getID();
             $relations_id = $relation->update($input);

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -183,13 +183,14 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
                   $ios->update(['id' => $ios->getID()] + $input_os);
                }
             } else {
+               $input_os['_no_history'] = $no_history;
                $ios->add($input_os);
             }
          }
 
          if ($pfConfig->getValue("component_simcard") != 0) {
             //Import simcards
-            $this->importSimcards('Computer', $a_computerinventory, $computers_id);
+            $this->importSimcards('Computer', $a_computerinventory, $computers_id, $no_history);
          }
 
       // * Computer

--- a/inc/inventorynetworkequipmentlib.class.php
+++ b/inc/inventorynetworkequipmentlib.class.php
@@ -123,7 +123,8 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
          'FROM'  => getTableForItemType("PluginFusioninventoryNetworkEquipment"),
          'WHERE' => ['networkequipments_id' => $items_id]
       ];
-      foreach ($DB->request($params) as $data) {
+      $iterator = $DB->request($params);
+      while ($data = $iterator->next()) {
          foreach ($data as $key=>$value) {
             $db_networkequipment[$key] = Toolbox::addslashes_deep($value);
          }

--- a/inc/inventorynetworkequipmentlib.class.php
+++ b/inc/inventorynetworkequipmentlib.class.php
@@ -63,7 +63,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
     * @param integer $items_id id of the networkequipment
     * @param boolean $no_history notice if changes must be logged or not
     */
-   function updateNetworkEquipment($a_inventory, $items_id, $no_history) {
+   function updateNetworkEquipment($a_inventory, $items_id, $no_history = false) {
       global $DB;
 
       $networkEquipment   = new NetworkEquipment();
@@ -108,7 +108,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
       //Add the location if needed (play rule locations engine)
       $input = PluginFusioninventoryToolbox::addLocation($input);
 
-      $networkEquipment->update($input, $no_history);
+      $networkEquipment->update($input, !$no_history);
 
       $this->internalPorts($a_inventory['internalport'],
                            $items_id,

--- a/inc/inventorynetworkequipmentlib.class.php
+++ b/inc/inventorynetworkequipmentlib.class.php
@@ -61,8 +61,9 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
     * @global object $DB
     * @param array $a_inventory data fron agent inventory
     * @param integer $items_id id of the networkequipment
+    * @param boolean $no_history notice if changes must be logged or not
     */
-   function updateNetworkEquipment($a_inventory, $items_id) {
+   function updateNetworkEquipment($a_inventory, $items_id, $no_history) {
       global $DB;
 
       $networkEquipment   = new NetworkEquipment();
@@ -107,7 +108,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
       //Add the location if needed (play rule locations engine)
       $input = PluginFusioninventoryToolbox::addLocation($input);
 
-      $networkEquipment->update($input);
+      $networkEquipment->update($input, $no_history);
 
       $this->internalPorts($a_inventory['internalport'],
                            $items_id,
@@ -117,11 +118,12 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
 
       // * NetworkEquipment fusion (ext)
       $db_networkequipment = array();
-      $query = "SELECT *
-         FROM `".  getTableForItemType("PluginFusioninventoryNetworkEquipment")."`
-         WHERE `networkequipments_id` = '$items_id'";
-      $result = $DB->query($query);
-      while ($data = $DB->fetch_assoc($result)) {
+
+      $params = [
+         'FROM'  => getTableForItemType("PluginFusioninventoryNetworkEquipment"),
+         'WHERE' => ['networkequipments_id' => $items_id]
+      ];
+      foreach ($DB->request($params) as $data) {
          foreach ($data as $key=>$value) {
             $db_networkequipment[$key] = Toolbox::addslashes_deep($value);
          }
@@ -140,19 +142,19 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
                      $a_inventory['PluginFusioninventoryNetworkEquipment'],
                      $db_networkequipment);
          $a_inventory['PluginFusioninventoryNetworkEquipment'] = $a_ret[0];
-         $input = $a_inventory['PluginFusioninventoryNetworkEquipment'];
-         $input['id'] = $idtmp;
+         $input                = $a_inventory['PluginFusioninventoryNetworkEquipment'];
+         $input['id']          = $idtmp;
          $pfNetworkEquipment->update($input);
       }
 
       // * Ports
-      $this->importPorts('NetworkEquipment', $a_inventory, $items_id);
+      $this->importPorts('NetworkEquipment', $a_inventory, $items_id, $no_history);
 
       //Import firmwares
-      $this->importFirmwares('NetworkEquipment', $a_inventory, $items_id);
+      $this->importFirmwares('NetworkEquipment', $a_inventory, $items_id, $no_history);
 
       //Import simcards
-      $this->importSimcards('NetworkEquipment', $a_inventory, $items_id);
+      $this->importSimcards('NetworkEquipment', $a_inventory, $items_id, $no_history);
 
    }
 
@@ -263,7 +265,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
     * @param array $a_inventory
     * @param integer $items_id
     */
-   function importPorts($itemtype, $a_inventory, $items_id) {
+   function importPorts($itemtype, $a_inventory, $items_id, $no_history = false) {
       //TODO : try to report this code in PluginFusioninventoryInventoryCommon::importPorts
       $pfNetworkporttype = new PluginFusioninventoryNetworkporttype();
       $networkPort       = new NetworkPort();
@@ -290,7 +292,7 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
                }
                $a_port['items_id'] = $items_id;
                $a_port['itemtype'] = 'NetworkEquipment';
-               $networkports_id = $networkPort->add($a_port);
+               $networkports_id = $networkPort->add($a_port, [], $no_history);
                unset($a_port['id']);
                $a_pfnetworkport_DB = current($pfNetworkPort->find(
                        "`networkports_id`='".$networkports_id."'", '', 1));

--- a/inc/inventoryprinterlib.class.php
+++ b/inc/inventoryprinterlib.class.php
@@ -63,7 +63,7 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
     * @param integer $printers_id id of the printer
     * @param boolean $no_history notice if changes must be logged or not
     */
-   function updatePrinter($a_inventory, $printers_id, $no_history) {
+   function updatePrinter($a_inventory, $printers_id, $no_history = false) {
       global $DB;
 
       $printer   = new Printer();
@@ -102,7 +102,7 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
       }
       //Add the location if needed (play rule locations engine)
       $input = PluginFusioninventoryToolbox::addLocation($input);
-      $printer->update($input, $no_history);
+      $printer->update($input, !$no_history);
 
       $db_printer = [];
 

--- a/inc/inventoryprinterlib.class.php
+++ b/inc/inventoryprinterlib.class.php
@@ -111,7 +111,8 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
          'FROM'  => getTableForItemType("PluginFusioninventoryPrinter"),
          'WHERE' => ['printers_id' => $printers_id]
       ];
-      foreach ($DB->request($params) as $data) {
+      $iterator = $DB->request($params);
+      while ($data = $iterator->next()) {
          foreach ($data as $key=>$value) {
             $db_printer[$key] = Toolbox::addslashes_deep($value);
          }

--- a/inc/inventoryprinterlib.class.php
+++ b/inc/inventoryprinterlib.class.php
@@ -61,8 +61,9 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
     * @global object $DB
     * @param array $a_inventory data fron agent inventory
     * @param integer $printers_id id of the printer
+    * @param boolean $no_history notice if changes must be logged or not
     */
-   function updatePrinter($a_inventory, $printers_id) {
+   function updatePrinter($a_inventory, $printers_id, $no_history) {
       global $DB;
 
       $printer   = new Printer();
@@ -92,7 +93,6 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
       $input                  = $a_inventory['Printer'];
       $input['id']            = $printers_id;
       $input['itemtype']      = 'Printer';
-
       if (isset($a_inventory['networkport'])) {
          foreach ($a_inventory['networkport'] as $a_port) {
             if (isset($a_port['ip'])) {
@@ -102,16 +102,16 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
       }
       //Add the location if needed (play rule locations engine)
       $input = PluginFusioninventoryToolbox::addLocation($input);
+      $printer->update($input, $no_history);
 
-      $printer->update($input);
+      $db_printer = [];
 
       // * Printer fusion (ext)
-      $db_printer = array();
-      $query = "SELECT *
-            FROM `".  getTableForItemType("PluginFusioninventoryPrinter")."`
-            WHERE `printers_id` = '$printers_id'";
-      $result = $DB->query($query);
-      while ($data = $DB->fetch_assoc($result)) {
+      $params = [
+         'FROM'  => getTableForItemType("PluginFusioninventoryPrinter"),
+         'WHERE' => ['printers_id' => $printers_id]
+      ];
+      foreach ($DB->request($params) as $data) {
          foreach ($data as $key=>$value) {
             $db_printer[$key] = Toolbox::addslashes_deep($value);
          }
@@ -122,7 +122,7 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
             $printers_id;
          $pfPrinter->add($a_inventory['PluginFusioninventoryPrinter']);
       } else { // Update
-         $idtmp = $db_printer['id'];
+         $idtmp      = $db_printer['id'];
          unset($db_printer['id']);
          unset($db_printer['printers_id']);
          unset($db_printer['plugin_fusioninventory_configsecurities_id']);
@@ -137,13 +137,13 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
       }
 
       // * Ports
-      $this->importPorts('Printer', $a_inventory, $printers_id);
+      $this->importPorts('Printer', $a_inventory, $printers_id, $no_history);
 
       //Import firmwares
-      $this->importFirmwares('Printer', $a_inventory, $printers_id);
+      $this->importFirmwares('Printer', $a_inventory, $printers_id, $no_history);
 
       //Import simcards
-      $this->importSimcards('Printer', $a_inventory, $printers_id);
+      $this->importSimcards('Printer', $a_inventory, $printers_id, $no_history);
 
       // Page counters
       $this->importPageCounters($a_inventory['pagecounters'], $printers_id);

--- a/phpunit/1_Unit/NetworkEquipmentUpdateTest.php
+++ b/phpunit/1_Unit/NetworkEquipmentUpdateTest.php
@@ -209,14 +209,14 @@ class NetworkEquipmentUpdate extends RestoreDatabase_TestCase {
 
       $this->assertGreaterThan(0, $this->items_id);
 
-      $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $this->items_id);
+      $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $this->items_id, 1);
 
       $DB->query("UPDATE `glpi_plugin_fusioninventory_networkporttypes`"
               ." SET `import`='0'"
               ." WHERE `number`='54'");
 
       // To be sure not have 2 sme informations
-      $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $this->items_id);
+      $pfiNetworkEquipmentLib->updateNetworkEquipment($a_inventory, $this->items_id, 0);
 
    }
 

--- a/phpunit/1_Unit/PrinterUpdateTest.php
+++ b/phpunit/1_Unit/PrinterUpdateTest.php
@@ -105,10 +105,10 @@ class PrinterUpdate extends RestoreDatabase_TestCase {
 
       $this->assertGreaterThan(0, $this->items_id);
 
-      $pfiPrinterLib->updatePrinter($a_inventory, $this->items_id);
+      $pfiPrinterLib->updatePrinter($a_inventory, $this->items_id, 1);
 
       // To be sure not have 2 sme informations
-      $pfiPrinterLib->updatePrinter($a_inventory, $this->items_id);
+      $pfiPrinterLib->updatePrinter($a_inventory, $this->items_id, 0);
 
    }
 
@@ -551,7 +551,7 @@ class PrinterUpdate extends RestoreDatabase_TestCase {
       ];
 
    $pfCNetworkInventory = new PluginFusioninventoryCommunicationNetworkInventory();
-   $pfCNetworkInventory->importDevice('Printer', $printers_id, $a_inventory);
+   $pfCNetworkInventory->importDevice('Printer', $printers_id, $a_inventory, 0);
 
    $a_ports = $networkPort->find("`itemtype`='Printer' AND `items_id`='".$printers_id."'");
    $this->assertEquals('1', count($a_ports), 'Should have only one port');

--- a/phpunit/2_Integration/DevicesLocksTest.php
+++ b/phpunit/2_Integration/DevicesLocksTest.php
@@ -370,7 +370,7 @@ class DevicesLocks extends RestoreDatabase_TestCase {
       $networkEquipment->add($input);
 
       $PLUGIN_FUSIONINVENTORY_XML = '';
-      $pfCommunicationNetworkInventory->importDevice('NetworkEquipment', 1, $a_inventory);
+      $pfCommunicationNetworkInventory->importDevice('NetworkEquipment', 1, $a_inventory, 1);
 
       $this->assertEquals(countElementsInTable('glpi_locations'), 0, 'Location has been created :/');
       $networkEquipment->getFromDB(1);


### PR DESCRIPTION
Harmonize log behavior at asset creation based on what's done for computers : 
- do not add a log entry during OS creation for a computer
- do not add log entries when manually inserting a XML of SNMP inventory for printers & network devices