### PR TITLE
Collected information as search criteria

### DIFF
--- a/b/collect/index.php
+++ b/b/collect/index.php
@@ -173,14 +173,14 @@ switch (filter_input(INPUT_GET, "action")) {
                   $computers_id,
                   $a_values,
                   $sid
-               );               
+               );
             }
 
-            // change status of state table row
-            $pfTaskjobstate->changeStatus($jobstate['id'],
-                       PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA);
+         // change status of state table row
+         $pfTaskjobstate->changeStatus($jobstate['id'],
+                    PluginFusioninventoryTaskjobstate::AGENT_HAS_SENT_DATA);
 
-            // add logs to job
+         // add logs to job
             if (count($a_values)) {
                $flag    = PluginFusioninventoryTaskjoblog::TASK_INFO;
                $message = json_encode($a_values, JSON_UNESCAPED_SLASHES);
@@ -188,13 +188,13 @@ switch (filter_input(INPUT_GET, "action")) {
                $flag    = PluginFusioninventoryTaskjoblog::TASK_ERROR;
                $message = __('Path not found', 'fusioninventory');
             }
-            $pfTaskjoblog->addTaskjoblog($jobstate['id'],
-                                         $jobstate['items_id'],
-                                         $jobstate['itemtype'],
-                                         $flag,
-                                         $message);
+         $pfTaskjoblog->addTaskjoblog($jobstate['id'],
+                                      $jobstate['items_id'],
+                                      $jobstate['itemtype'],
+                                      $flag,
+                                      $message);
          }
-         break;
+      break;
 
 
 
@@ -205,7 +205,7 @@ switch (filter_input(INPUT_GET, "action")) {
                                              $jobstate['items_id'],
                                              $jobstate['itemtype']);
 
-         break;
+      break;
       }
 
    if (count($response) > 0) {

--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -165,7 +165,7 @@ class PluginFusioninventoryCollect extends CommonDBTM {
       $i = 5200;
 
       $pfCollect = new PluginFusioninventoryCollect();
-      foreach ($pfCollect->find(getEntitiesRestrictRequest("", $pfCollect->getTable())) as $collect) {
+      foreach ($pfCollect->find(getEntitiesRestrictRequest("", $pfCollect->getTable(), '', '', true)) as $collect) {
 
          //registries
          $pfCollect_Registry = new PluginFusioninventoryCollect_Registry();
@@ -179,7 +179,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
             $tab[$i]['datatype']      = 'text';
             $tab[$i]['forcegroupby']  = true;
             $tab[$i]['massiveaction'] = false;
-            $tab[$i]['nodisplay']     = true;
             $tab[$i]['joinparams']    = array('condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_registries_id` = ".$registry['id'],
                                           'jointype' => 'child');
             $i++;
@@ -197,7 +196,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
             $tab[$i]['datatype']      = 'text';
             $tab[$i]['forcegroupby']  = true;
             $tab[$i]['massiveaction'] = false;
-            $tab[$i]['nodisplay']     = true;
             $tab[$i]['joinparams']    = array('condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_wmis_id` = ".$wmi['id'],
                                           'jointype' => 'child');
             $i++;
@@ -218,7 +216,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
             $tab[$i]['datatype']      = 'text';
             $tab[$i]['forcegroupby']  = true;
             $tab[$i]['massiveaction'] = false;
-            $tab[$i]['nodisplay']     = true;
             $tab[$i]['joinparams']    = array('condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_files_id` = ".$file['id'],
                                           'jointype' => 'child');
             $i++;
@@ -233,7 +230,6 @@ class PluginFusioninventoryCollect extends CommonDBTM {
             $tab[$i]['datatype']      = 'text';
             $tab[$i]['forcegroupby']  = true;
             $tab[$i]['massiveaction'] = false;
-            $tab[$i]['nodisplay']     = true;
             $tab[$i]['joinparams']    = array('condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_files_id` = ".$file['id'],
                                           'jointype' => 'child');
             $i++;

--- a/phpunit/2_Integration/CollectsTest.php
+++ b/phpunit/2_Integration/CollectsTest.php
@@ -120,7 +120,7 @@ class CollectsTest extends RestoreDatabase_TestCase {
          'datatype'         => 'text',
          'forcegroupby'     => true,
          'massiveaction'    => false,
-         'nodisplay'        => true,
+//         'nodisplay'        => true,
          'joinparams'       => array(
             'condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_registries_id` = 1",
             'jointype'  => 'child'
@@ -137,7 +137,7 @@ class CollectsTest extends RestoreDatabase_TestCase {
          'datatype'         => 'text',
          'forcegroupby'     => true,
          'massiveaction'    => false,
-         'nodisplay'        => true,
+//         'nodisplay'        => true,
          'joinparams'       => array(
             'condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_wmis_id` = 1",
             'jointype'  => 'child'
@@ -155,7 +155,7 @@ class CollectsTest extends RestoreDatabase_TestCase {
          'datatype'         => 'text',
          'forcegroupby'     => true,
          'massiveaction'    => false,
-         'nodisplay'        => true,
+//         'nodisplay'        => true,
          'joinparams'       => array(
             'condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_files_id` = 1",
             'jointype'  => 'child'
@@ -173,7 +173,7 @@ class CollectsTest extends RestoreDatabase_TestCase {
          'datatype'         => 'text',
          'forcegroupby'     => true,
          'massiveaction'    => false,
-         'nodisplay'        => true,
+//         'nodisplay'        => true,
          'joinparams'       => array(
             'condition' => "AND NEWTABLE.`plugin_fusioninventory_collects_files_id` = 1",
             'jointype'  => 'child'


### PR DESCRIPTION
Close #2471 - get collected information restricted entities recursively
Close #2467 - collected information are no more 'nodisplay', this to allow using in a WS table response

Because the same code is impacted, I pushed the 2 commits in this same PR... easier to review and merge 😉 