### PR TITLE
Fix #2416: set an entities_id for collected fields

### DIFF
--- a/inc/collectrule.class.php
+++ b/inc/collectrule.class.php
@@ -142,11 +142,11 @@ class PluginFusioninventoryCollectRule extends Rule {
                               && $action->fields["field"] != 'otherserial'
                               && $action->fields["field"] != 'software'
                               && $action->fields["field"] != 'softwareversion')) {
-                     $res = Dropdown::importExternal(
-                             getItemTypeForTable(
-                                     getTableNameForForeignKeyField(
-                                             $action->fields['field'])),
-                             $res);
+                     $entities_id = 0;
+                     if (isset($_SESSION["plugin_fusioninventory_entity"])) {
+                        $entities_id = $_SESSION["plugin_fusioninventory_entity"];
+                     }
+                     $res = Dropdown::importExternal(getItemtypeForForeignKeyField($action->fields['field']), $res, $entities_id);
                   }
                   $output[$action->fields["field"]] = $res;
                   break;

--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -465,8 +465,7 @@ class PluginFusioninventoryCommunicationNetworkDiscovery {
             if (!in_array('domain', $a_lockable)) {
                if (isset($arrayinventory['WORKGROUP'])
                        && !empty($arrayinventory['WORKGROUP'])) {
-               $input['domain'] = Dropdown::importExternal("Domain",
-                                       $arrayinventory['WORKGROUP'], $arrayinventory['ENTITY']);
+               $input['domain'] = Dropdown::importExternal("Domain", $arrayinventory['WORKGROUP'], $arrayinventory['ENTITY']);
                }
             }
             if (!empty($arrayinventory['TYPE'])) {

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -1631,8 +1631,12 @@ class PluginFusioninventoryFormatconvert {
 
                      //Add the current manufacturer to the cache of manufacturers
                      if (!isset($this->manufacturer_cache[$array_tmp['manufacturers_id']])) {
-                        $new_value = Dropdown::importExternal('Manufacturer',
-                                                              $array_tmp['manufacturers_id']);
+                        $entities_id = 0;
+                        if (isset($_SESSION["plugin_fusioninventory_entity"])) {
+                           $entities_id = $_SESSION["plugin_fusioninventory_entity"];
+                        }
+                        $new_value = Dropdown::importExternal(
+                           'Manufacturer', $array_tmp['manufacturers_id'], $entities_id);
                         $this->manufacturer_cache[$array_tmp['manufacturers_id']] = $new_value;
                      }
                      //Set the manufacturer using the cache
@@ -1919,8 +1923,7 @@ class PluginFusioninventoryFormatconvert {
                      $manufacturer = new Manufacturer();
                      $array[$key]  = $manufacturer->processName($value);
                      if ($key == 'bios_manufacturers_id') {
-                        $this->foreignkey_itemtype[$key] =
-                                 getItemTypeForTable(getTableNameForForeignKeyField('manufacturers_id'));
+                        $this->foreignkey_itemtype[$key] = getItemtypeForForeignKeyField('manufacturers_id');
                      } else {
                         if (isset($CFG_GLPI['plugin_fusioninventory_computermanufacturer'][$value])) {
                            $CFG_GLPI['plugin_fusioninventory_computermanufacturer'][$value] = $array[$key];
@@ -1928,21 +1931,18 @@ class PluginFusioninventoryFormatconvert {
                      }
                   }
                   if (!is_numeric($key)) {
+                     $entities_id = 0;
+                     if (isset($_SESSION["plugin_fusioninventory_entity"])) {
+                        $entities_id = $_SESSION["plugin_fusioninventory_entity"];
+                     }
                      if ($key == "locations_id") {
-                        $array[$key] = Dropdown::importExternal('Location',
-                                                                $value,
-                                                                $_SESSION["plugin_fusioninventory_entity"]);
+                        $array[$key] = Dropdown::importExternal('Location', $value, $entities_id);
                      } else if (isset($this->foreignkey_itemtype[$key])) {
-                        $array[$key] = Dropdown::importExternal($this->foreignkey_itemtype[$key],
-                                                                $value,
-                                                                $_SESSION["plugin_fusioninventory_entity"]);
+                        $array[$key] = Dropdown::importExternal($this->foreignkey_itemtype[$key], $value, $entities_id);
                      } else if (isForeignKeyField($key)
                              && $key != "users_id") {
-                        $this->foreignkey_itemtype[$key] =
-                                    getItemTypeForTable(getTableNameForForeignKeyField($key));
-                        $array[$key] = Dropdown::importExternal($this->foreignkey_itemtype[$key],
-                                                                $value,
-                                                                $_SESSION["plugin_fusioninventory_entity"]);
+                        $this->foreignkey_itemtype[$key] = getItemtypeForForeignKeyField($key);
+                        $array[$key] = Dropdown::importExternal($this->foreignkey_itemtype[$key], $value, $entities_id);
 
                         if ($key == 'operatingsystemkernelversions_id'
                            && isset($array['operatingsystemkernels_id'])

--- a/inc/inventoryrulelocation.class.php
+++ b/inc/inventoryrulelocation.class.php
@@ -152,12 +152,7 @@ class PluginFusioninventoryInventoryRuleLocation extends Rule {
                              && $_SESSION["plugin_fusioninventory_entity"] > 0) {
                         $entities_id = $_SESSION["plugin_fusioninventory_entity"];
                      }
-                     $res = Dropdown::importExternal(
-                             getItemTypeForTable(
-                                     getTableNameForForeignKeyField(
-                                             $action->fields['field'])),
-                             $res,
-                             $entities_id);
+                     $res = Dropdown::importExternal(getItemtypeForForeignKeyField($action->fields['field']), $res, $entities_id);
                   }
                   $output[$action->fields["field"]] = $res;
                   break;


### PR DESCRIPTION
This to conform with the Glpi Statuses that are entities aware where as the FI plugin did not managed this for all the collected fields.

Successfuly tested on the most recent GLPI 9.2 and FI current 9.2 RC1