### PR TITLE
PluginFusioninventoryItem::showForm() fix

### DIFF
--- a/inc/item.class.php
+++ b/inc/item.class.php
@@ -134,17 +134,7 @@ class PluginFusioninventoryItem extends CommonDBTM {
     * @param array $options optional parameters to be used for display purpose
     */
    function showForm(CommonDBTM $item, $options = []) {
-      $PluginFusioninventoryProfile = new PluginFusioninventoryProfile();
-      $rights = $PluginFusioninventoryProfile->getRightsInventory();
-      $class  = get_class($this);
-
-      $aRight = array_filter($rights, function($a) use ($class) {
-         return (isset($a['itemtype']) && $a['itemtype'] == "$class");
-      });
-      $aRight = reset($aRight);
-      $right  = $aRight['field'];
-
-      Session::checkRight($right, READ);
+      Session::checkRight($this::$rightname, READ);
 
       $fk     = getForeignKeyFieldForItemType($this->itemtype);
       $params = [$fk => $item->getID()];

--- a/inc/item.class.php
+++ b/inc/item.class.php
@@ -206,7 +206,7 @@ class PluginFusioninventoryItem extends CommonDBTM {
       echo "<tr class='tab_bg_2 center'>";
       echo "<td colspan='4'>";
       echo "<div align='center'>";
-      echo Html::hidden('id', ['value' => $this->fields['id']]);
+      echo Html::hidden('id', ['value' => $this->fields[$fk]]);
       echo Html::submit(__('Update'), ['name' => 'update']);
       echo "</td>";
       echo "</tr>";

--- a/inc/item.class.php
+++ b/inc/item.class.php
@@ -134,7 +134,17 @@ class PluginFusioninventoryItem extends CommonDBTM {
     * @param array $options optional parameters to be used for display purpose
     */
    function showForm(CommonDBTM $item, $options = []) {
-      Session::checkRight('plugin_fusioninventory_printer', READ);
+      $PluginFusioninventoryProfile = new PluginFusioninventoryProfile();
+      $rights = $PluginFusioninventoryProfile->getRightsInventory();
+      $class  = get_class($this);
+
+      $aRight = array_filter($rights, function($a) use ($class) {
+         return (isset($a['itemtype']) && $a['itemtype'] == "$class");
+      });
+      $aRight = reset($aRight);
+      $right  = $aRight['field'];
+
+      Session::checkRight($right, READ);
 
       $fk     = getForeignKeyFieldForItemType($this->itemtype);
       $params = [$fk => $item->getID()];


### PR DESCRIPTION
The very first issue i had was SNMP community not updated due to an incorrect 'id' POSTed to front/switch_info.form.php, see the second commit.

Then i noticed an erroneous call Session::checkRight('plugin_fusioninventory_printer', READ), see the first commit.