### PR TITLE
Manage last boot field in computer inventory

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -187,6 +187,13 @@ function plugin_fusioninventory_getAddSearchOptions($itemtype) {
       $sopt[5181]['joinparams']  = ['jointype' => 'child'];
       $sopt[5181]['massiveaction'] = false;
 
+      $sopt[5182]['table']     = 'glpi_plugin_fusioninventory_inventorycomputercomputers';
+      $sopt[5182]['field']     = 'last_boot';
+      $sopt[5182]['name']      = __('FusInv', 'fusioninventory')." - ".__('Last boot', 'fusioninventory');
+      $sopt[5182]['joinparams']  = ['jointype' => 'child'];
+      $sopt[5182]['datatype']  = 'datetime';
+      $sopt[5182]['massiveaction'] = false;
+
    }
 
    if ($itemtype == 'Computer') {

--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -371,6 +371,10 @@ class PluginFusioninventoryFormatconvert {
          $a_inventory['fusioninventorycomputer']['operatingsystem_installationdate'] =
                      $array['OPERATINGSYSTEM']['INSTALL_DATE'];
       }
+      if (isset($array['OPERATINGSYSTEM']['BOOT_TIME'])
+              && !empty($array['OPERATINGSYSTEM']['BOOT_TIME'])) {
+         $a_inventory['fusioninventorycomputer']['last_boot'] = $array['OPERATINGSYSTEM']['BOOT_TIME'];
+      }
 
       if (isset($array['HARDWARE']['DESCRIPTION'])) {
          $a_inventory['fusioninventorycomputer']['oscomment'] = $array['HARDWARE']['DESCRIPTION'];
@@ -378,6 +382,10 @@ class PluginFusioninventoryFormatconvert {
 
       if (empty($a_inventory['fusioninventorycomputer']['operatingsystem_installationdate'])) {
          $a_inventory['fusioninventorycomputer']['operatingsystem_installationdate'] = "NULL";
+      }
+
+      if (empty($a_inventory['fusioninventorycomputer']['last_boot'])) {
+         $a_inventory['fusioninventorycomputer']['last_boot'] = "NULL";
       }
 
       // * BIOS

--- a/inc/inventorycomputercomputer.class.php
+++ b/inc/inventorycomputercomputer.class.php
@@ -249,28 +249,28 @@ class PluginFusioninventoryInventoryComputerComputer extends PluginFusioninvento
       echo '<th colspan="4">'.__('FusionInventory', 'fusioninventory').'</th>';
       echo '</tr>';
 
+      $pfAgent = new PluginFusioninventoryAgent();
+      $pfAgent->showInfoForComputer($item, 4);
+
       echo '<tr class="tab_bg_1">';
+      if ($a_computerextend['remote_addr'] != '') {
+         echo '<td>'.__('Public contact address', 'fusioninventory').'</td>';
+         echo '<td>'.$a_computerextend['remote_addr'].'</td>';
+      } else {
+         echo "<td colspan='2'></td>";
+      }
+
       echo '<td>';
       echo __('Last inventory', 'fusioninventory');
       echo '</td>';
       echo '<td>';
       echo Html::convDateTime($a_computerextend['last_fusioninventory_update']);
       echo '</td>';
-
-      if ($a_computerextend['remote_addr'] != '') {
-         echo '<td>'.__('Public contact address', 'fusioninventory').'</td>';
-         echo '<td>'.$a_computerextend['remote_addr'].'</td>';
-      }
-      echo "<td colspan='2'></td>";
-
       echo '</tr>';
 
-      $pfAgent = new PluginFusioninventoryAgent();
-      $pfAgent->showInfoForComputer($item, 4);
-
+      echo '<tr class="tab_bg_1">';
       // Display automatic entity transfer
       if (Session::isMultiEntitiesMode()) {
-         echo '<tr class="tab_bg_1">';
          echo '<td>'.__('Automatic entity transfer', 'fusioninventory').'</td>';
          echo '<td>';
          $pfEntity = new PluginFusioninventoryEntity();
@@ -288,8 +288,16 @@ class PluginFusioninventoryInventoryComputerComputer extends PluginFusioninvento
             }
          }
          echo '</td>';
-         echo '</tr>';
+      } else {
+         echo "<td colspan='2'></td>";
       }
+      echo '<td>';
+      echo __('Last boot', 'fusioninventory');
+      echo '</td>';
+      echo '<td>';
+      echo Html::convDateTime($a_computerextend['last_boot']);
+      echo '</td>';
+      echo '</tr>';
 
       $pfRemoteManagement = new PluginFusioninventoryComputerRemoteManagement();
       $pfRemoteManagement->showInformation($item->getID());

--- a/install/mysql/plugin_fusioninventory-empty.sql
+++ b/install/mysql/plugin_fusioninventory-empty.sql
@@ -385,6 +385,7 @@ CREATE TABLE `glpi_plugin_fusioninventory_inventorycomputercomputers` (
   `is_entitylocked` tinyint(1) NOT NULL DEFAULT '0',
   `oscomment` text DEFAULT NULL,
   `hostid` varchar(255) DEFAULT NULL,
+  `last_boot` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `computers_id` (`computers_id`),
   KEY `last_fusioninventory_update` (`last_fusioninventory_update`)

--- a/install/update.php
+++ b/install/update.php
@@ -2739,25 +2739,27 @@ function do_computercomputer_migration($migration) {
 
    $a_table['fields']  = [];
    $a_table['fields']['id']                     = ['type'    => 'autoincrement',
-                                                        'value'   => ''];
+                                                   'value'   => ''];
    $a_table['fields']['computers_id']           = ['type'    => 'integer',
-                                                        'value'   => null];
+                                                   'value'   => null];
    $a_table['fields']['operatingsystem_installationdate'] = ['type'    => 'datetime',
-                                                                  'value'   => null];
+                                                             'value'   => null];
    $a_table['fields']['winowner']               = ['type'    => 'string',
-                                                        'value'   => null];
+                                                   'value'   => null];
    $a_table['fields']['wincompany']             = ['type'    => 'string',
-                                                        'value'   => null];
+                                                   'value'   => null];
    $a_table['fields']['last_fusioninventory_update']     = ['type'    => 'datetime',
-                                                                 'value'   => null];
+                                                            'value'   => null];
    $a_table['fields']['remote_addr']            = ['type'    => 'string',
-                                                        'value'   => null];
+                                                   'value'   => null];
    $a_table['fields']['serialized_inventory']   = ['type'    => 'longblob',
-                                                        'value'   => null];
+                                                   'value'   => null];
    $a_table['fields']['is_entitylocked']        = ['type'    => 'bool',
-                                                        'value'   => "0"];
+                                                   'value'   => "0"];
    $a_table['fields']['oscomment']              = ['type'    => 'text',
-                                                        'value'   => null];
+                                                   'value'   => null];
+   $a_table['fields']['last_boot']              = ['type'    => 'datetime',
+                                                   'value'   => null];
 
    $a_table['oldfields']  = [
       'plugin_fusioninventory_computerarchs_id',

--- a/phpunit/1_Unit/ComputerLogTest.php
+++ b/phpunit/1_Unit/ComputerLogTest.php
@@ -66,7 +66,8 @@ class ComputerLog extends RestoreDatabase_TestCase {
               'winowner'                        => 'test',
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> '2012-10-16 08:12:56',
-              'last_fusioninventory_update'     => $date
+              'last_fusioninventory_update'     => $date,
+              'last_boot'                       => '2018-06-11 08:03:32',
           ],
           'soundcard'      => [],
           'graphiccard'    => [],

--- a/phpunit/1_Unit/ComputerTransformationTest.php
+++ b/phpunit/1_Unit/ComputerTransformationTest.php
@@ -96,6 +96,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                      => '',
               'operatingsystem_installationdate'=> 'NULL',
               'last_fusioninventory_update'     => $date,
+              'last_boot'                       => 'NULL',
               'oscomment'                       => 'amd64/-1-11-30 22:04:44',
               'items_operatingsystems_id'       => [
                 'operatingsystems_id'              => 'freebsd',
@@ -190,6 +191,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                      => '',
               'operatingsystem_installationdate'=> 'NULL',
               'last_fusioninventory_update'     => $date,
+              'last_boot'                       => 'NULL',
               'items_operatingsystems_id' => [
                   'operatingsystems_id'              => '',
                   'operatingsystemversions_id'       => '',
@@ -292,6 +294,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                               => 'siprossii',
               'operatingsystem_installationdate'         => '2012-10-16 08:12:56',
               'last_fusioninventory_update'              => $date,
+              'last_boot'                                => 'NULL',
               'oscomment'                                => '',
               'items_operatingsystems_id' => [
                   'operatingsystems_id'              => 'Windows',
@@ -1003,6 +1006,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> 'NULL',
               'last_fusioninventory_update'     => $date,
+              'last_boot'                       => 'NULL',
               'oscomment'                       => '',
               'items_operatingsystems_id' => [
                   'operatingsystems_id'              => 'Microsoft Windows XP Professionnel',
@@ -1323,6 +1327,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                               => 'siprossii',
               'operatingsystem_installationdate'         => 'NULL',
               'last_fusioninventory_update'              => $date,
+              'last_boot'                                => 'NULL',
               'oscomment'                                => '',
               'items_operatingsystems_id' => [
                   'operatingsystems_id'              => 'Microsoft Windows XP Professionnel',
@@ -1438,6 +1443,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                               => 'siprossii',
               'operatingsystem_installationdate'         => 'NULL',
               'last_fusioninventory_update'              => $date,
+              'last_boot'                                => 'NULL',
               'oscomment'                                => '',
               'items_operatingsystems_id'                => [
                   'operatingsystems_id'              => 'Microsoft Windows XP Professionnel',
@@ -1947,6 +1953,7 @@ class ComputerTransformation extends RestoreDatabase_TestCase {
               'wincompany'                               => 'siprossii',
               'operatingsystem_installationdate'         => 'NULL',
               'last_fusioninventory_update'              => $date,
+              'last_boot'                                => 'NULL',
               'oscomment'                                => '',
               'items_operatingsystems_id'                => [
                   'operatingsystems_id'              => 'Microsoft Windows XP Professionnel',

--- a/phpunit/1_Unit/ComputerUpdateTest.php
+++ b/phpunit/1_Unit/ComputerUpdateTest.php
@@ -70,6 +70,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> '2012-10-16 08:12:56',
               'last_fusioninventory_update'     => $date,
+              'last_boot'                       => '2018-06-11 08:03:32',
               'items_operatingsystems_id'       => [
                   'operatingsystems_id'              => 'freebsd',
                   'operatingsystemversions_id'       => '9.1-RELEASE',
@@ -394,6 +395,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
           'id'                                        => '1',
           'computers_id'                              => '1',
           'operatingsystem_installationdate'          => '2012-10-16 08:12:56',
+          'last_boot'                                 => '2018-06-11 08:03:32',
           'winowner'                                  => 'test',
           'wincompany'                                => 'siprossii',
           'remote_addr'                               => null,
@@ -1196,6 +1198,7 @@ class ComputerUpdateTest extends RestoreDatabase_TestCase {
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> '2012-10-16 08:12:56',
               'last_fusioninventory_update'     => $date,
+              'last_boot'                       => 'NULL',
               'items_operatingsystems_id'       => [
                   'operatingsystems_id'              => 'freebsd',
                   'operatingsystemversions_id'       => '9.1-RELEASE',

--- a/phpunit/1_Unit/VirtualmachineTest.php
+++ b/phpunit/1_Unit/VirtualmachineTest.php
@@ -53,7 +53,8 @@ class VirtualmachineTest extends RestoreDatabase_TestCase {
               'winowner'                        => 'test',
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> '2012-10-16 08:12:56',
-              'last_fusioninventory_update'     => date('Y-m-d H:i:s')
+              'last_fusioninventory_update'     => date('Y-m-d H:i:s'),
+              'last_boot'                       => '2018-06-11 08:03:32',
           ],
           'soundcard'      => [],
           'graphiccard'    => [],

--- a/phpunit/2_Integration/ComputerDynamicTest.php
+++ b/phpunit/2_Integration/ComputerDynamicTest.php
@@ -265,7 +265,8 @@ class ComputerDynamic extends RestoreDatabase_TestCase {
               'winowner'                        => 'test',
               'wincompany'                      => 'siprossii',
               'operatingsystem_installationdate'=> '2012-10-16 08:12:56',
-              'last_fusioninventory_update'     => date('Y-m-d H:i:s')
+              'last_fusioninventory_update'     => date('Y-m-d H:i:s'),
+              'last_boot'                       => '2018-06-11 08:03:32',
           ],
           'soundcard'      => [],
           'graphiccard'    => [],


### PR DESCRIPTION
* Add last boot field into GLPI + in search engine
* re-order FusionInventory fields in computer form: 

Before:

![before](https://user-images.githubusercontent.com/239744/42558588-03835a5e-84f2-11e8-945d-fc31428978fb.png)

After:

 ![after](https://user-images.githubusercontent.com/239744/42558582-fd869d32-84f1-11e8-8f9d-b8004b4676fe.png)


