### PR TITLE
Add 'start job now' support on deploy audit check failure

### DIFF
--- a/inc/deploycheck.class.php
+++ b/inc/deploycheck.class.php
@@ -239,6 +239,14 @@ class PluginFusioninventoryDeployCheck extends PluginFusioninventoryDeployPackag
          if ($canedit) {
             echo "</a>";
          }
+
+         if ($check['return'] === 'startnow') {
+            echo "<br />";
+            $warning = sprintf(__('Fusioninventory-Agent %1s or higher mandatory'), '2.4.2');
+            echo "<img src='".$CFG_GLPI['root_doc']."/pics/warning_min.png'>";
+            echo "<span class='red'><i>".$warning."</i></span>";
+         }
+
          echo "<br />";
          $type_values = $this->getLabelsAndTypes($check['type'], false);
          if (isset($type_values['path_label'])) {
@@ -563,6 +571,7 @@ class PluginFusioninventoryDeployCheck extends PluginFusioninventoryDeployPackag
    function getAllReturnValues() {
       return  ["error"   => __('abort job', 'fusioninventory'),
                "skip"    => __("skip job", 'fusioninventory'),
+               "startnow" => __("start job now", 'fusioninventory'),
                "info"    => __("report info", 'fusioninventory'),
                "warning" => __("report warning", 'fusioninventory')
               ];

--- a/phpunit/1_Unit/Deploy/DeploycheckTest.php
+++ b/phpunit/1_Unit/Deploy/DeploycheckTest.php
@@ -436,7 +436,7 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
       $check = new PluginFusioninventoryDeployCheck();
       $this->assertEquals('abort job', $check->getValueForReturn('error'));
       $this->assertEquals('skip job', $check->getValueForReturn('skip'));
-      $this->assertEquals('start job now', $check->getValueForReturn('startjobnow'));
+      $this->assertEquals('start job now', $check->getValueForReturn('startnow'));
       $this->assertEquals('report info', $check->getValueForReturn('info'));
       $this->assertEquals('report warning', $check->getValueForReturn('warning'));
       $this->assertEquals('', $check->getValueForReturn('foo'));

--- a/phpunit/1_Unit/Deploy/DeploycheckTest.php
+++ b/phpunit/1_Unit/Deploy/DeploycheckTest.php
@@ -421,6 +421,7 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
       $values = $check->getAllReturnValues();
       $expected = ["error"    => __('abort job', 'fusioninventory'),
                    "skip"     => __("skip job", 'fusioninventory'),
+                   "startnow" => __("start job now", 'fusioninventory'),
                    "info"     => __("report info", 'fusioninventory'),
                    "warning"  => __("report warning", 'fusioninventory')
                ];
@@ -435,6 +436,7 @@ class DeploycheckTest extends RestoreDatabase_TestCase {
       $check = new PluginFusioninventoryDeployCheck();
       $this->assertEquals('abort job', $check->getValueForReturn('error'));
       $this->assertEquals('skip job', $check->getValueForReturn('skip'));
+      $this->assertEquals('start job now', $check->getValueForReturn('startjobnow'));
       $this->assertEquals('report info', $check->getValueForReturn('info'));
       $this->assertEquals('report warning', $check->getValueForReturn('warning'));
       $this->assertEquals('', $check->getValueForReturn('foo'));


### PR DESCRIPTION
Add a new choice for deployment audit check failure: **`start job now`**

This permits to simply bypass all remaining checks deciding the job still can be started in the case a condition fails.

For example, you can decide to not continue the audit and install a package after checking a registry key exists but you found it doesn't.

This feature will need FusionInventory Agent 2.4.2 (see [PR #564](https://github.com/fusioninventory/fusioninventory-agent/pull/564)).

As agent 2.4.2 use is mandatory, a warning is shown in the audit list.