### PR TITLE
Update rule arguments for GLPI 9.3.2

### DIFF
--- a/inc/collectrule.class.php
+++ b/inc/collectrule.class.php
@@ -113,9 +113,10 @@ class PluginFusioninventoryCollectRule extends Rule {
     *
     * @param array $output
     * @param array $params
+    * @param array $input
     * @return array
     */
-   function executeActions($output, $params) {
+   function executeActions($output, $params, array $input = []) {
 
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-rules-collect",

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -173,7 +173,7 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
             //OS exists, check for updates
             $same = true;
             foreach ($input_os as $key => $value) {
-               if ($ios->fields[$key] != $value) {
+               if (key_exists($key, $ios->fields) && $ios->fields[$key] != $value) {
                   $same = false;
                   break;
                }

--- a/inc/inventoryruleentity.class.php
+++ b/inc/inventoryruleentity.class.php
@@ -115,9 +115,10 @@ class PluginFusioninventoryInventoryRuleEntity extends Rule {
     *
     * @param array $output
     * @param array $params
+    * @param array $input
     * @return array
     */
-   function executeActions($output, $params) {
+   function executeActions($output, $params, array $input = []) {
 
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-rules-entity",

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -714,9 +714,10 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
     *
     * @param array $output
     * @param array $params
+    * @param array $input
     * @return array
     */
-   function executeActions($output, $params) {
+   function executeActions($output, $params, array $input = []) {
       if (isset($params['class'])) {
          $class = $params['class'];
       } else if (isset($_SESSION['plugin_fusioninventory_classrulepassed'])) {

--- a/inc/inventoryrulelocation.class.php
+++ b/inc/inventoryrulelocation.class.php
@@ -115,9 +115,10 @@ class PluginFusioninventoryInventoryRuleLocation extends Rule {
     *
     * @param array $output
     * @param array $params
+    * @param array $input
     * @return array
     */
-   function executeActions($output, $params) {
+   function executeActions($output, $params, array $input = []) {
 
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-rules-location",


### PR DESCRIPTION
Hello,

This PR is for fixing a wrong method compatibility with GLPI 9.3.2 because a new argument added to the executeActions method.

![imagen](https://user-images.githubusercontent.com/1426313/46737533-ba0f5700-cc69-11e8-9727-c14b541c608d.png)
