### PR TITLE
Handle file size = 0 in collect file information

### DIFF
--- a/b/collect/index.php
+++ b/b/collect/index.php
@@ -156,7 +156,7 @@ switch (filter_input(INPUT_GET, "action")) {
                break;
 
             case 'file':
-               if (!empty($a_values['path']) && !empty($a_values['size'])) {
+               if (!empty($a_values['path'])) {
                   // update files content
                   $params = [
                      'machineid' => $pfAgent->fields['device_id'],


### PR DESCRIPTION
When the file size is equal to zero, the empty function returns true and the collect answer fails with error "collect type not found"