### PR TITLE
Add computers_id in searchOptions for rest API

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -216,6 +216,14 @@ class PluginFusioninventoryAgent extends CommonDBTM {
          'datatype'  => 'integer',
       ];
 
+      $tab[] = [
+         'id'        => '15',
+         'table'     => $this->getTable(),
+         'field'     => 'computers_id',
+         'name'      => __('Computer id', 'fusioninventory'),
+         'datatype'  => 'integer',
+      ];
+
       $i = 20;
       $pfAgentmodule = new PluginFusioninventoryAgentmodule();
       $a_modules = $pfAgentmodule->find();


### PR DESCRIPTION
This is a lite enhancement related to issue #2698 , adding the computers ID to the searchOptions of class PluginFusioninventoryAgent. This allows to find the computer by the help of the agent name when using the rest API.