### PR TITLE
provide manufacturer name when importing computer's model in dictionnary

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -1929,6 +1929,13 @@ class PluginFusioninventoryFormatconvert {
       $a_lockable = PluginFusioninventoryLock::getLockFields(getTableForItemType($itemtype),
                                                              $items_id);
 
+      // save raw manufacture name before its replacement by id for importing model
+      // (we need manufacturers name in when importing model in dictionary)
+      $manufacture_name = "";
+      if (isset($array['manufacturers_id'])) {
+         $manufacture_name = $array['manufacturers_id'];
+      }
+
       foreach ($array as $key=>$value) {
          if (!is_int($key)
                  && ($key == "software"
@@ -1966,6 +1973,12 @@ class PluginFusioninventoryFormatconvert {
                      }
                      if ($key == "locations_id") {
                         $array[$key] = Dropdown::importExternal('Location', $value, $entities_id);
+                     } else if ($key == "computermodels_id") {
+                        // computer model need manufacturer relation for dictionary import
+                        // see CommonDCModelDropdown::$additional_fields_for_dictionnary
+                        $array[$key] = Dropdown::importExternal('ComputerModel', $value, $entities_id, [
+                           'manufacturer' => $manufacture_name
+                        ]);
                      } else if (isset($this->foreignkey_itemtype[$key])) {
                         $array[$key] = Dropdown::importExternal($this->foreignkey_itemtype[$key], $value, $entities_id);
                      } else if (isForeignKeyField($key)

--- a/phpunit/1_Unit/FormatConvertDataTest.php
+++ b/phpunit/1_Unit/FormatConvertDataTest.php
@@ -123,13 +123,44 @@ class FormatConvertDataTest extends RestoreDatabase_TestCase {
 
       $DB->connect();
 
+      // create a computer's model dictionnay to test import with manufacturer
+      $rule = new RuleDictionnaryComputerModel;
+      $rules_id = $rule->add([
+         'sub_type'  => 'RuleDictionnaryComputerModel',
+         'name'      => 'test import with manufacturer',
+         'is_active' => 1,
+         'match'     => 'AND'
+      ]);
+      $ruleacriteria = new RuleCriteria;
+      $ruleaaction   = new RuleAction;
+      $ruleacriteria->add([
+         'rules_id'  => $rules_id,
+         'criteria'  => 'name',
+         'condition' => Rule::PATTERN_CONTAIN,
+         'pattern'   => 'XPS 13',
+      ]);
+      $ruleacriteria->add([
+         'rules_id'  => $rules_id,
+         'criteria'  => 'manufacturer',
+         'condition' => Rule::PATTERN_CONTAIN,
+         'pattern'   => 'Dell',
+      ]);
+      $ruleaaction->add([
+         'rules_id'    => $rules_id,
+         'action_type' => 'assign',
+         'field'       => 'name',
+         'value'       => 'Modified by dictionary',
+      ]);
+
       $a_inventory['software'] = [];
       $a_inventory['Computer'] = [
-          'name'                             => 'pc',
-          'users_id'                         => 0,
-          'operatingsystems_id'              => 'freebsd',
-          'operatingsystemversions_id'       => '9.1-RELEASE'
-          ];
+         'name'                       => 'pc',
+         'users_id'                   => 0,
+         'operatingsystems_id'        => 'freebsd',
+         'operatingsystemversions_id' => '9.1-RELEASE',
+         'manufacturers_id'           => 'Dell Inc.',
+         'computermodels_id'          => 'XPS 13 9350'
+      ];
 
       $_SESSION["plugin_fusioninventory_entity"] = 0;
       $pfFormatconvert = new PluginFusioninventoryFormatconvert();
@@ -137,13 +168,19 @@ class FormatConvertDataTest extends RestoreDatabase_TestCase {
 
       $a_reference['software'] = [];
       $a_reference['Computer'] = [
-          'name'                             => 'pc',
-          'users_id'                         => 0,
-          'operatingsystems_id'              => 1,
-          'operatingsystemversions_id'       => 1
-          ];
+         'name'                       => 'pc',
+         'users_id'                   => 0,
+         'operatingsystems_id'        => 1,
+         'operatingsystemversions_id' => 1,
+         'manufacturers_id'           => 1,
+         'computermodels_id'          => 1
+      ];
 
-       $this->assertEquals($a_reference, $a_inventory);
+      $this->assertEquals($a_reference, $a_inventory);
+
+      $computer_model = new ComputerModel;
+      $computer_model->getFromDB(1);
+      $this->assertEquals($computer_model->fields['name'], "Modified by dictionary");
 
       $GLPIlog = new GLPIlogs();
       $GLPIlog->testSQLlogs();


### PR DESCRIPTION
When a computer's model dictionary set a manufacturer criterion, it's never provided by fusioninventory.
Ex: 
![image](https://user-images.githubusercontent.com/418844/50902617-abc50880-141b-11e9-9d66-2708a1723074.png)
