### PR TITLE
Fix plugin states warnings during update tests

### DIFF
--- a/phpunit/0_Install/FusinvInstallTest.php
+++ b/phpunit/0_Install/FusinvInstallTest.php
@@ -41,6 +41,7 @@
  */
 
 require_once("0_Install/FusinvDB.php");
+require_once __DIR__ . "/../../inc/config.class.php";
 
 class FusinvInstallTest extends Common_TestCase {
 

--- a/phpunit/0_Install/mysql/i-0.83+2.1.sql
+++ b/phpunit/0_Install/mysql/i-0.83+2.1.sql
@@ -96,10 +96,10 @@ INSERT INTO `glpi_displaypreferences` (`id`, `itemtype`, `num`, `rank`, `users_i
 DELETE FROM glpi_plugins where directory='fusioninventory';
 
 INSERT INTO `glpi_plugins` (`id`, `directory`, `name`, `version`, `state`, `author`, `homepage`, `license`) VALUES
-(2, 'fusinvinventory', 'FusionInventory INVENTORY', '0.83+2.1', 1, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
-(5, 'fusioninventory', 'FusionInventory', '0.83+2.1', 1, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
-(9, 'fusinvdeploy', 'FusionInventory DEPLOY', '0.83+2.1', 1, '<a href=''http://www.teclib.com''>TECLIB''</a> and the FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
-(21, 'fusinvsnmp', 'FusionInventory SNMP', '0.83+2.1', 1, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+');
+(2, 'fusinvinventory', 'FusionInventory INVENTORY', '0.83+2.1', 4, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
+(5, 'fusioninventory', 'FusionInventory', '0.83+2.1', 6, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
+(9, 'fusinvdeploy', 'FusionInventory DEPLOY', '0.83+2.1', 4, '<a href=''http://www.teclib.com''>TECLIB''</a> and the FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+'),
+(21, 'fusinvsnmp', 'FusionInventory SNMP', '0.83+2.1', 4, '<a href="mailto:d.durieux@siprossii.com">David DURIEUX</a>\n                                    & FusionInventory team', 'http://forge.fusioninventory.org/projects/fusioninventory-for-glpi/', 'AGPLv3+');
 
 
 CREATE TABLE IF NOT EXISTS `glpi_plugin_fusinvdeploy_actions` (

--- a/scripts/cli_install.php
+++ b/scripts/cli_install.php
@@ -119,7 +119,7 @@ if (!is_null($args['--as-user'])) {
 print("Running...\n");
 
 $plugin = new Plugin();
-$plugin->checkStates(true);
+$plugin->checkPluginState('fusioninventory');
 $plugin->init();
 
 require_once (GLPI_ROOT . "/plugins/fusioninventory/install/climigration.class.php");


### PR DESCRIPTION
Initial state of plugins in fixtures should not be "ACTIVATED" as normal procedure is to disable plugins prior to begin their upgrade process.