### PR TITLE
Fix compatibility with CLI install command from GLPI core

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -826,7 +826,9 @@ function plugin_fusioninventory_install() {
    ini_set("max_execution_time", "0");
 
    if (basename(filter_input(INPUT_SERVER, "SCRIPT_NAME")) != "cli_install.php") {
-      Html::header(__('Setup'), filter_input(INPUT_SERVER, "PHP_SELF"), "config", "plugins");
+      if (!isCommandLine()) {
+         Html::header(__('Setup'), filter_input(INPUT_SERVER, "PHP_SELF"), "config", "plugins");
+      }
       $migrationname = 'Migration';
    } else {
       $migrationname = 'CliMigration';


### PR DESCRIPTION
A new CLI command has been introduced in GLPI 9.5 to install plugins. It uses the `install` hook, so HTML header should not be displayed in CLI context to prevent outputing HTML in CLI context.

See https://github.com/glpi-project/glpi/pull/5862.