### PR TITLE
Add an option to enable monitor serialnumber partial matching

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -112,6 +112,7 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       $input['import_registry']        = 1;
       $input['import_process']         = 1;
       $input['import_vm']              = 1;
+      $input['import_monitor_on_partial_sn'] = 0;
       $input['component_processor']    = 1;
       $input['component_memory']       = 1;
       $input['component_harddrive']    = 1;
@@ -591,7 +592,12 @@ class PluginFusioninventoryConfig extends CommonDBTM {
       echo "<td>";
       Dropdown::showYesNo("manage_osname", $pfConfig->getValue('manage_osname'));
       echo "</td>";
-      echo "<td colspan='2'></td>";
+      echo "<td>";
+      echo __('Import monitor on serial partial match:', 'fusioninventory');
+      echo "</td>";
+      echo "<td>";
+      Dropdown::showYesNo("import_monitor_on_partial_sn", $pfConfig->getValue('import_monitor_on_partial_sn'));
+      echo "</td>";
       echo "</tr>";
 
       echo "<tr class='tab_bg_1'>";

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -570,11 +570,11 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
                      OR `[typetable]`.`serial`='".$serial2."')";
                   $_SESSION["plugin_fusioninventory_serialHP"] = $serial2;
 
-               // Support partial match for monitor serial
                } else if (isset($input['itemtype'])
                        AND $input['itemtype'] == 'Monitor'
                        AND $pfConfig->getValue('import_monitor_on_partial_sn') == 1
                        AND strlen($input["serial"]) >= 4) {
+                  // Support partial match for monitor serial
                   $sql_where_temp = " AND `[typetable]`.`serial` LIKE '%".$input["serial"]."%'";
                } else {
                   $sql_where_temp = " AND `[typetable]`.`serial`='".$input["serial"]."'";

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -396,6 +396,8 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
    function findWithGlobalCriteria($input) {
       global $DB, $CFG_GLPI;
 
+      $pfConfig = new PluginFusioninventoryConfig();
+
       PluginFusioninventoryToolbox::logIfExtradebug(
          "pluginFusioninventory-rules",
          $input
@@ -568,6 +570,11 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
                      OR `[typetable]`.`serial`='".$serial2."')";
                   $_SESSION["plugin_fusioninventory_serialHP"] = $serial2;
 
+               // Support partial match for monitor serial
+               } else if (isset($input['itemtype'])
+                       AND $input['itemtype'] == 'Monitor'
+                       AND $pfConfig->getValue('import_monitor_on_partial_sn') == 1) {
+                  $sql_where_temp = " AND `[typetable]`.`serial` LIKE '%".$input["serial"]."%'";
                } else {
                   $sql_where_temp = " AND `[typetable]`.`serial`='".$input["serial"]."'";
                }

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -573,7 +573,8 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
                // Support partial match for monitor serial
                } else if (isset($input['itemtype'])
                        AND $input['itemtype'] == 'Monitor'
-                       AND $pfConfig->getValue('import_monitor_on_partial_sn') == 1) {
+                       AND $pfConfig->getValue('import_monitor_on_partial_sn') == 1
+                       AND strlen($input["serial"]) >= 4) {
                   $sql_where_temp = " AND `[typetable]`.`serial` LIKE '%".$input["serial"]."%'";
                } else {
                   $sql_where_temp = " AND `[typetable]`.`serial`='".$input["serial"]."'";

--- a/install/update.php
+++ b/install/update.php
@@ -863,6 +863,7 @@ function pluginFusioninventoryUpdate($current_version, $migrationname = 'Migrati
       'import_registry'                => 1,
       'import_process'                 => 1,
       'import_vm'                      => 1,
+      'import_monitor_on_partial_sn'   => 0,
       'component_processor'            => 1,
       'component_memory'               => 1,
       'component_harddrive'            => 1,


### PR DESCRIPTION
Option is disabled by default

As monitor serial numbers are very badly handled by manufacturers in EDID block, the one found by the agent is often partly the one visible on the device itself. When people manually adds monitors in its stock, it will of course put as serial number the one found on device itself or on its packaging.
So this option could be enabled when people starts to see duplicated monitors with serial numbers partially different. This won't merge duplicated entries, so people will always have to delete one of the duplicated entries (the one from the dynamic inventory as first choice).