### PR TITLE
Only unset locked values on itemtype related nodes

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -2005,7 +2005,7 @@ class PluginFusioninventoryFormatconvert {
                         }
                      }
                   }
-               } else {
+               } else if (in_array($itemtype, ['Computer', 'NetworkEquipment', 'Printer'])) {
                   unset($array[$key]);
                }
             }


### PR DESCRIPTION
This PR should fix a lot of undefined value issues like #2536.

We need to avoid to unset values on recursively handled types. The problem is locks are only looked for the $items_id one in `glpi_plugin_fusioninventory_locks` table, even if the type is not Computer, NetworkEquipment or Printer during the recursive calls. As example, if the type is 'monitor' or 'peripheral' and a lock exists for the $item_id monitor or peripheral (even if $item_id peripheral is in fact linked to another computer), the lock will be applied.

To reproduce on the monitor case, start from a clean instance. Import a computer with a monitor. This will create a entry in glpi_computers with id `1` and a monitor with id `1` in glpi_monitors. Computer and monitor are linked. Go an edit the monitor 1, set a different name and a different serial. This will create a lock for glpi_monitors id 1 entry. Try to import again the computer. You'll obtain an error in php-errors.log and no monitor will be linked to the computer. If you only modify the name, you'll only obtain the undefined name error. You can trigger also the same on peripheral when editing the same way the peripheral id 1 (always same id than computer one). In the case you have 2 peripherals linked to the computer id 1, editing the peripheral id 2 won't make any problem... until you import another computer which will have the id 2.

A better fix would be to only look for $a_lockable array in replaceids() API when convenient, i.e. when the item type can be locked with the associated $items_id.