### PR TITLE
Fix : Import Xml Virtual Machine creation uuid

### DIFF
--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -1008,7 +1008,7 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
                      'FROM'   => 'glpi_computers',
                      'WHERE'  => [
                         'RAW' => [
-                           'LOWER(uuid)'  => self::getUUIDRestrictCriteria($fields['uuid'])
+                           'LOWER(uuid)'  => ComputerVirtualMachine::getUUIDRestrictCriteria($fields['uuid'])
                         ]
                      ],
                      'LIMIT'  => 1

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -1008,7 +1008,7 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
                      'FROM'   => 'glpi_computers',
                      'WHERE'  => [
                         'RAW' => [
-                           'LOWER(uuid)'  => ComputerVirtualMachine::getUUIDRestrictCriteria($fields['uuid'])
+                           'LOWER(uuid)'  => ComputerVirtualMachine::getUUIDRestrictCriteria($a_vm['uuid'])
                         ]
                      ],
                      'LIMIT'  => 1


### PR DESCRIPTION
Hello,
My Host in Hyper-V doesn't retrieve full inventory.
This is because getUUIDRestrictCriteria not exist in PluginFusioninventoryInventoryComputerLib class.
So I correct call of self::getUUIDRestrictCriteria to ComputerVirtualMachine::getUUIDRestrictRequest like commented L996 and before regression from https://github.com/fusioninventory/fusioninventory-for-glpi/commit/e71c81ed95e03d68d6c22fbafba8e001f47bfd48.