### PR TITLE
Fix netdiscovery/netinventory default timeout and threads number usage

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -488,7 +488,8 @@ class PluginFusioninventoryAgent extends CommonDBTM {
       echo "<td align='center'>";
       Dropdown::showNumber("timeout_networkdiscovery", [
              'value' => $this->fields["timeout_networkdiscovery"],
-             'min' => 0,
+             'toadd' => [ __('General setup') ],
+             'min' => 1,
              'max' => 60]
          );
       echo "</td>";
@@ -519,7 +520,8 @@ class PluginFusioninventoryAgent extends CommonDBTM {
       echo "<td align='center'>";
       Dropdown::showNumber("timeout_networkinventory", [
              'value' => $this->fields["timeout_networkinventory"],
-             'min' => 0,
+             'toadd' => [ __('General setup') ],
+             'min' => 1,
              'max' => 60]
       );
       echo "</td>";

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -471,6 +471,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
       echo "<td align='center'>";
       Dropdown::showNumber("threads_networkdiscovery", [
              'value' => $this->fields["threads_networkdiscovery"],
+             'toadd' => [ __('General setup') ],
              'min' => 1,
              'max' => 400]
          );
@@ -505,6 +506,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
       echo "<td align='center'>";
       Dropdown::showNumber("threads_networkinventory", [
              'value' => $this->fields["threads_networkinventory"],
+             'toadd' => [ __('General setup') ],
              'min' => 1,
              'max' => 400]
       );
@@ -606,6 +608,9 @@ class PluginFusioninventoryAgent extends CommonDBTM {
             $a_input['entities_id']  = 0;
             $a_input['last_contact'] = date("Y-m-d H:i:s");
             $a_input['useragent'] = filter_input(INPUT_SERVER, "HTTP_USER_AGENT");
+            // Set default number of threads for network tasks to 0 to follow general setup
+            $a_input['threads_networkdiscovery1'] = 0;
+            $a_input['threads_networkinventory1'] = 0;
             $agents_id = $this->add($a_input);
             if ($agents_id) {
                return $agents_id;

--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -609,8 +609,8 @@ class PluginFusioninventoryAgent extends CommonDBTM {
             $a_input['last_contact'] = date("Y-m-d H:i:s");
             $a_input['useragent'] = filter_input(INPUT_SERVER, "HTTP_USER_AGENT");
             // Set default number of threads for network tasks to 0 to follow general setup
-            $a_input['threads_networkdiscovery1'] = 0;
-            $a_input['threads_networkinventory1'] = 0;
+            $a_input['threads_networkdiscovery'] = 0;
+            $a_input['threads_networkinventory'] = 0;
             $agents_id = $this->add($a_input);
             if ($agents_id) {
                return $agents_id;

--- a/inc/networkdiscovery.class.php
+++ b/inc/networkdiscovery.class.php
@@ -336,9 +336,16 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
       $sxml_param = $sxml_option->addChild('PARAM');
       $sxml_param->addAttribute('THREADS_DISCOVERY',
          $pfAgent->fields["threads_networkdiscovery"]);
-      $sxml_param->addAttribute('TIMEOUT',
-         $pfAgent->fields["timeout_networkdiscovery"]);
-      $sxml_param->addAttribute('PID', $jobstate->fields['id']);
+      // Use general config when timeout is set to 0 on the agent
+      if ($pfAgent->fields["timeout_networkdiscovery"]<1) {
+         $pfConfig = new PluginFusioninventoryConfig();
+         $sxml_param->addAttribute('TIMEOUT',
+            $pfConfig->getValue('timeout_networkdiscovery'));
+      } else {
+         $sxml_param->addAttribute('TIMEOUT',
+            $pfAgent->fields["timeout_networkdiscovery"]);
+      }
+       $sxml_param->addAttribute('PID', $jobstate->fields['id']);
 
       $changestate = 0;
       $taskjobstatedatas = $jobstate->fields;

--- a/inc/networkdiscovery.class.php
+++ b/inc/networkdiscovery.class.php
@@ -327,6 +327,7 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
       $pfTaskjoblog = new PluginFusioninventoryTaskjoblog();
       $pfIPRange = new PluginFusioninventoryIPRange();
       $pfToolbox = new PluginFusioninventoryToolbox();
+      $pfConfig = new PluginFusioninventoryConfig();
 
       $pfAgent->getFromDB($jobstate->fields['plugin_fusioninventory_agents_id']);
 
@@ -334,11 +335,16 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
       $sxml_option->addChild('NAME', 'NETDISCOVERY');
 
       $sxml_param = $sxml_option->addChild('PARAM');
-      $sxml_param->addAttribute('THREADS_DISCOVERY',
-         $pfAgent->fields["threads_networkdiscovery"]);
+      // Use general config when threads number is set to 0 on the agent
+      if ($pfAgent->fields["threads_networkdiscovery"]<1) {
+         $sxml_param->addAttribute('THREADS_DISCOVERY',
+            $pfConfig->getValue('threads_networkdiscovery'));
+      } else {
+         $sxml_param->addAttribute('THREADS_DISCOVERY',
+            $pfAgent->fields["threads_networkdiscovery"]);
+      }
       // Use general config when timeout is set to 0 on the agent
       if ($pfAgent->fields["timeout_networkdiscovery"]<1) {
-         $pfConfig = new PluginFusioninventoryConfig();
          $sxml_param->addAttribute('TIMEOUT',
             $pfConfig->getValue('timeout_networkdiscovery'));
       } else {

--- a/inc/networkdiscovery.class.php
+++ b/inc/networkdiscovery.class.php
@@ -336,7 +336,7 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
 
       $sxml_param = $sxml_option->addChild('PARAM');
       // Use general config when threads number is set to 0 on the agent
-      if ($pfAgent->fields["threads_networkdiscovery"]<1) {
+      if ($pfAgent->fields["threads_networkdiscovery"] == 0) {
          $sxml_param->addAttribute('THREADS_DISCOVERY',
             $pfConfig->getValue('threads_networkdiscovery'));
       } else {
@@ -344,7 +344,7 @@ class PluginFusioninventoryNetworkdiscovery extends PluginFusioninventoryCommuni
             $pfAgent->fields["threads_networkdiscovery"]);
       }
       // Use general config when timeout is set to 0 on the agent
-      if ($pfAgent->fields["timeout_networkdiscovery"]<1) {
+      if ($pfAgent->fields["timeout_networkdiscovery"] == 0) {
          $sxml_param->addAttribute('TIMEOUT',
             $pfConfig->getValue('timeout_networkdiscovery'));
       } else {

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -575,6 +575,7 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
       $pfTaskjoblog = new PluginFusioninventoryTaskjoblog();
       $pfConfigSecurity = new PluginFusioninventoryConfigSecurity();
       $pfToolbox = new PluginFusioninventoryToolbox();
+      $pfConfig = new PluginFusioninventoryConfig();
 
       $current = $jobstate;
       $pfAgent->getFromDB($current->fields['plugin_fusioninventory_agents_id']);
@@ -593,11 +594,16 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
          $sxml_option = $this->message->addChild('OPTION');
          $sxml_option->addChild('NAME', 'SNMPQUERY');
          $sxml_param = $sxml_option->addChild('PARAM');
-         $sxml_param->addAttribute('THREADS_QUERY',
-            $pfAgent->fields["threads_networkinventory"]);
+         // Use general config when threads number is set to 0 on the agent
+         if ($pfAgent->fields["threads_networkinventory"]<1) {
+            $sxml_param->addAttribute('THREADS_QUERY',
+               $pfConfig->getValue('threads_networkinventory'));
+         } else {
+            $sxml_param->addAttribute('THREADS_QUERY',
+               $pfAgent->fields["threads_networkinventory"]);
+         }
          // Use general config when timeout is set to 0 on the agent
          if ($pfAgent->fields["timeout_networkinventory"]<1) {
-            $pfConfig = new PluginFusioninventoryConfig();
             $sxml_param->addAttribute('TIMEOUT',
                $pfConfig->getValue('timeout_networkinventory'));
          } else {

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -595,7 +595,7 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
          $sxml_option->addChild('NAME', 'SNMPQUERY');
          $sxml_param = $sxml_option->addChild('PARAM');
          // Use general config when threads number is set to 0 on the agent
-         if ($pfAgent->fields["threads_networkinventory"]<1) {
+         if ($pfAgent->fields["threads_networkinventory"] == 0) {
             $sxml_param->addAttribute('THREADS_QUERY',
                $pfConfig->getValue('threads_networkinventory'));
          } else {
@@ -603,7 +603,7 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
                $pfAgent->fields["threads_networkinventory"]);
          }
          // Use general config when timeout is set to 0 on the agent
-         if ($pfAgent->fields["timeout_networkinventory"]<1) {
+         if ($pfAgent->fields["timeout_networkinventory"] == 0) {
             $sxml_param->addAttribute('TIMEOUT',
                $pfConfig->getValue('timeout_networkinventory'));
          } else {

--- a/inc/networkinventory.class.php
+++ b/inc/networkinventory.class.php
@@ -595,8 +595,15 @@ class PluginFusioninventoryNetworkinventory extends PluginFusioninventoryCommuni
          $sxml_param = $sxml_option->addChild('PARAM');
          $sxml_param->addAttribute('THREADS_QUERY',
             $pfAgent->fields["threads_networkinventory"]);
-         $sxml_param->addAttribute('TIMEOUT',
-            $pfAgent->fields["timeout_networkinventory"]);
+         // Use general config when timeout is set to 0 on the agent
+         if ($pfAgent->fields["timeout_networkinventory"]<1) {
+            $pfConfig = new PluginFusioninventoryConfig();
+            $sxml_param->addAttribute('TIMEOUT',
+               $pfConfig->getValue('timeout_networkinventory'));
+         } else {
+            $sxml_param->addAttribute('TIMEOUT',
+               $pfAgent->fields["timeout_networkinventory"]);
+         }
          $sxml_param->addAttribute('PID', $current->fields['id']);
 
          $changestate = 0;

--- a/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
+++ b/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
@@ -302,6 +302,7 @@ class NetworkInventoryTest extends RestoreDatabase_TestCase {
           'version'     => '{"INVENTORY":"v2.3.11"}',
           'device_id'   => 'computer1',
           'useragent'   => 'FusionInventory-Agent_v2.3.11',
+          'threads_networkinventory' => 0,
           'computers_id'=> $computers_id
       ];
       $pfAgent->add($input);

--- a/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
+++ b/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
@@ -373,7 +373,7 @@ class NetworkInventoryTest extends RestoreDatabase_TestCase {
             'NAME' => 'SNMPQUERY',
             'PARAM' => [
                '@attributes' => [
-                  'THREADS_QUERY' => 1,
+                  'THREADS_QUERY' => 10,
                   'TIMEOUT'       => 15,
                   'PID'           => 1
                ]

--- a/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
+++ b/phpunit/2_Integration/Tasks/NetworkInventoryTest.php
@@ -374,7 +374,7 @@ class NetworkInventoryTest extends RestoreDatabase_TestCase {
             'PARAM' => [
                '@attributes' => [
                   'THREADS_QUERY' => 1,
-                  'TIMEOUT'       => 0,
+                  'TIMEOUT'       => 15,
                   'PID'           => 1
                ]
             ],


### PR DESCRIPTION
Actually timeout sent to the agent for netdiscovery & netinventory tasks only comes from the agent configuration. The "General Setup" is never used.

As the default value set in database when an agent is created is "0", and as a "0" timeout is generally meaning "use the default", I uses this value to decide to provide the "General setup" value in place to the agent.

On the agent side, "0" means "use default" and default is 60 seconds... This is not what is though in the plugin as the general setup default is "1" second for netdiscovery and "15" for netinventory.

This may lead to misunderstandings when a task seems to be stick but it is waiting a minute for each ip to respond...

In the PR, I uses `__('General setup')` as default text for "0", but I'm not sure this is the better to use.