### PR TITLE
Revert "Optimize is_array"

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -222,8 +222,7 @@ class PluginFusioninventoryFormatconvert {
     */
    static function cleanArray($data) {
       foreach ($data as $key=>$value) {
-         //if (is_array($value)) {
-         if ((array)$value === $value) {
+         if (is_array($value)) {
             if (count($value) == 0) {
                $value = '';
             } else {
@@ -1885,8 +1884,7 @@ class PluginFusioninventoryFormatconvert {
     */
    static function addValues($array, $a_key) {
       $a_return = [];
-      //if (!is_array($array)) {
-      if ((array)$array !== $array) {
+      if (!is_array($array)) {
          return $a_return;
       }
       foreach ($array as $key=>$value) {
@@ -1949,8 +1947,7 @@ class PluginFusioninventoryFormatconvert {
             // do nothing
             $coding_std = true;
          } else {
-            //if (is_array($value)) {
-            if ((array)$value === $value) {
+            if (is_array($value)) {
                $new_itemtype = $itemtype;
                if ($level == 0) {
                   $new_itemtype = $key;


### PR DESCRIPTION
This reverts commit 68c6259061787bb68be9553e4b8d362c8f4d072b.

Since PHP 7, `is_array` is faster than casting
```
is_array  :  0.046628952026367
cast, === :  0.18426394462585

Tested 1000000 iterations.
```