### PR TITLE
Prevent error on os migration

### DIFF
--- a/inc/formatconvert.class.php
+++ b/inc/formatconvert.class.php
@@ -857,7 +857,7 @@ class PluginFusioninventoryFormatconvert {
                         } else if (isset($array_tmp["instantiation_type"])
                                 AND ($array_tmp["instantiation_type"] == 'fibrechannel'
                                     OR $array_tmp["instantiation_type"] == 'fiberchannel')
-                                OR !empty($array_tmp['wwn']) ) {
+                                OR !empty($array_tmp['wwn'])) {
                            $array_tmp["instantiation_type"] = 'NetworkPortFiberchannel';
                         } else if ($array_tmp['mac'] != '') {
                            $array_tmp["instantiation_type"] = 'NetworkPortEthernet';

--- a/install/update.php
+++ b/install/update.php
@@ -5122,7 +5122,7 @@ function do_computeroperatingsystem_migration($migration) {
          ];
 
          $computer = new Computer();
-         $computer->getFromDB($row['computers_id']);
+         $computer->getFromDB($row['cid']);
 
          $input = $search + [
             'operatingsystemversions_id'        => $row['operatingsystemversions_id'],


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

When trying to update FusionInventory we have some logs 

```
SQL: INSERT INTO `glpi_items_operatingsystems` (`itemtype`, `items_id`, `operatingsystems_id`, `operatingsystemarchitectures_id`, `operatingsystemversions_id`, `operatingsystemservicepacks_id`, `operatingsystemkernelversions_id`, `operatingsystemeditions_id`, `is_dynamic`, `entities_id`, `is_recursive`, `date_creation`, `date_mod`) VALUES ('Computer', '31839', '2', '1', '0', '1', '21483', '0', '1', NULL, NULL, '2019-12-04 13:35:10', '2019-12-04 13:35:10')

Error: Column 'entities_id' cannot be null

Backtrace :

inc/dbmysql.class.php:866                         

inc/commondbtm.class.php:659                       DBmysql->insert()

inc/commondbtm.class.php:1141                      CommonDBTM->addToDB()

plugins/fusioninventory/install/update.php:5139    CommonDBTM->add()

plugins/fusioninventory/install/update.php:385     do_computeroperatingsystem_migration()

plugins/fusioninventory/hook.php:849               pluginFusioninventoryUpdate()

inc/plugin.class.php:521                           plugin_fusioninventory_install()

...ins/fusioninventory/scripts/cli_install.php:175 Plugin->install()
```
It's appears that Fusioninventory try to load computer from an alias which no exist on previous SQL query.

This PR fix this.

Best regards
