### PR TITLE
Fix folder collect process

### DIFF
--- a/b/collect/index.php
+++ b/b/collect/index.php
@@ -158,13 +158,17 @@ switch (filter_input(INPUT_GET, "action")) {
                break;
 
             case 'file':
-               if (!empty($a_values['path']) && !empty($a_values['size'])) {
+               if (!empty($a_values['path'])) {
+                  $msg ="file ".$a_values['path'];
+                  if (!empty($a_values['size']) && $a_values['size'] > 0) {
+                     $msg .= " | size ".$a_values['size'];
+                  }
                   // update files content
                   $params = [
                      'machineid' => $pfAgent->fields['device_id'],
                      'uuid'      => filter_input(INPUT_GET, "uuid"),
                      'code'      => 'running',
-                     'msg'       => "file ".$a_values['path']." | size ".$a_values['size']
+                     'msg'       => $msg
                   ];
                   PluginFusioninventoryCommunicationRest::updateLog($params);
                   $pfCollect_subO = new PluginFusioninventoryCollect_File_Content();


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

When FusionInventory Agent collect try to known if folder exist or not, if exist
the response contains only path info (rather an path and size).
```
[debug2] [http client] POST: action=setAnswer&size=0&uuid=5e16f40621ee6&_glpi_csrf_token=637eff7ea569661703b507762892d2bd&_sid=5&_cpt=1&path=C%3A%5CUsers%5Cteclib%5CAppData%5CLocal%5CTemp%2Ftata
```

But plugin check if size information is present.

This PR  prevent this

Best regards

depend : #2915 