### PR TITLE
Add missing {

### DIFF
--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -883,6 +883,7 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
                               && is_numeric($value)
                               && $value > 0) {
                            $this->criterias_results['found_port'] = $value;
+                        }
                      }
                   }
                }


### PR DESCRIPTION
Fixes `ParseError: syntax error, unexpected 'getItemTypesForRules' (T_STRING), expecting '('` that make tests fails (see https://travis-ci.org/fusioninventory/fusioninventory-for-glpi/jobs/641337057 ).