### PR TITLE
Update Travis configuration to matches GLPI 9.5 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,21 @@ cache:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       addons:
         mariadb: 10.2
         apt:
           packages:
             - ant
             - xsltproc
-    - php: 7.1
-      env: CS=true
-      addons:
-        mariadb: 10.3
-        apt:
-          packages:
-            - ant
-            - xsltproc
-    - php: 7.2
-      addons:
-        mariadb: 10.3
-        apt:
-          packages:
-            - ant
-            - xsltproc
     - php: 7.3
+      addons:
+        mariadb: 10.3
+        apt:
+          packages:
+            - ant
+            - xsltproc
+    - php: 7.4
       addons:
         mariadb: 10.3
         apt:
@@ -57,7 +49,7 @@ before_install:
  - git clone --depth=10 -b $GLPI git://github.com/glpi-project/glpi.git glpi
  - cd glpi
  - nvm install --lts=dubnium # update node to dubnium LTS version (node v10.x + npm v6.4.1)
- - bin/console dependencies install --ci
+ - bin/console dependencies install --composer-options="--prefer-dist --no-progress"
  - cd ..
  - mysql -u root -e "CREATE DATABASE glpi;"
  - mv -f fusioninventory-for-glpi glpi/plugins/fusioninventory
@@ -71,8 +63,6 @@ before_install:
  - popd
 
 before_script:
-  - phpenv version-name | grep ^5.[34] && echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
-  - phpenv version-name | grep ^5.[34] && echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini ; true
   - phpenv config-rm xdebug.ini
   - php -S localhost:8088 -t glpi > /dev/null 2>&1 &
 
@@ -80,4 +70,4 @@ script:
  - composer install
  - mysql -u root -e 'select version();'
  - ant -Dclearsavepoint='true' -Dbasedir=. -f ./glpi/plugins/fusioninventory/phpunit/build.xml phpunit.all
- - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then cd glpi/plugins/fusioninventory && composer install && php vendor/bin/robo --no-interaction code:cs; fi
+ - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.4" ]]; then cd glpi/plugins/fusioninventory && composer install && php vendor/bin/robo --no-interaction code:cs; fi


### PR DESCRIPTION
- drop support of PHP < 7.2
- add support of PHP 7.4
- update dependencies install command params
- remove useless config related to PHP 5.3/5.4