### PR TITLE
Fix#2286: default states_id should not erase locked states_id

### DIFF
--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -195,7 +195,9 @@ class PluginFusioninventoryInventoryComputerLib extends CommonDBTM {
             $history = FALSE;
          }
          $input['_no_history'] = $no_history;
-         PluginFusioninventoryInventoryComputerInventory::addDefaultStateIfNeeded($input);
+         if (!in_array('states_id', $a_lockable)) {
+             PluginFusioninventoryInventoryComputerInventory::addDefaultStateIfNeeded($input);
+         }
          $computer->update($input, !$no_history);
 
       $this->computer = $computer;


### PR DESCRIPTION
Backport commit efd5eb0377629281328903fbe14e19917b923d7e into 9.1 branch