### PR TITLE
Check if bios exist  before add or update

### DIFF
--- a/inc/inventorycommon.class.php
+++ b/inc/inventorycommon.class.php
@@ -98,7 +98,7 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
          //Check if firmware relation with equipment already exist
          if ($relation->getFromDBByCrit($input)) {
             //if firmware id != between XML and DB update it relation
-            if($fid != $relation->fields['devicefirmwares_id']){
+            if ($fid != $relation->fields['devicefirmwares_id']) {
                $relation->fields['devicefirmwares_id'] = $fid;
                $relation->fields['is_dynamic'] = 1;
                $relation->fields['entities_id'] = $_SESSION['glpiactive_entity'];

--- a/inc/inventorycommon.class.php
+++ b/inc/inventorycommon.class.php
@@ -94,12 +94,20 @@ class PluginFusioninventoryInventoryCommon extends CommonDBTM {
          $input = [
             'itemtype'           => $itemtype,
             'items_id'           => $items_id,
-            'devicefirmwares_id' => $fid
          ];
-         //Check if firmware relation with equipment
-         $relation->getFromDBByCrit($input);
-         if ($relation->isNewItem()) {
+         //Check if firmware relation with equipment already exist
+         if ($relation->getFromDBByCrit($input)) {
+            //if firmware id != between XML and DB update it relation
+            if($fid != $relation->fields['devicefirmwares_id']){
+               $relation->fields['devicefirmwares_id'] = $fid;
+               $relation->fields['is_dynamic'] = 1;
+               $relation->fields['entities_id'] = $_SESSION['glpiactive_entity'];
+               $relation->update($relation->fields);
+            }
+         } else {
+            //create link
             $input = $input + [
+               'devicefirmwares_id' => $fid,
                'is_dynamic'   => 1,
                'entities_id'  => $_SESSION['glpiactive_entity']
             ];

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -2099,16 +2099,30 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
       $fwTypes->getFromDBByCrit([
          'name' => 'BIOS'
       ]);
-      $type_id = $fwTypes->getID();
-      $data['devicefirmwaretypes_id'] = $type_id;
 
-      $bios_id = $deviceBios->import($data);
-      $data['devicefirmwares_id']   = $bios_id;
       $data['itemtype']             = 'Computer';
       $data['items_id']             = $computers_id;
-      $data['is_dynamic']           = 1;
-      $data['_no_history']          = $no_history;
-      $item_DeviceBios->add($data, [], !$no_history);
+
+
+      $type_id = $fwTypes->getID();
+      $bios_id = $deviceBios->import($data);
+
+      //check if bios (dynamically inventoried) already exist for computer
+      if ($item_DeviceBios->getFromDBByCrit($data)) {
+         if ($item_DeviceBios->fields['devicefirmwares_id'] != $bios_id) {
+            $item_DeviceBios->fields['_no_history']          = !$no_history;
+            $item_DeviceBios->fields['devicefirmwares_id']   = $bios_id;
+            $item_DeviceBios->fields['devicefirmwaretypes_id'] = $type_id;
+            $item_DeviceBios->fields['is_dynamic']           = 1;
+            $item_DeviceBios->update($item_DeviceBios->fields,$no_history);
+         }
+      } else {
+         $data['_no_history']          = $no_history;
+         $data['devicefirmwares_id']   = $bios_id;
+         $data['devicefirmwaretypes_id'] = $type_id;
+         $data['is_dynamic']           = 1;
+         $item_DeviceBios->add($data, [], !$no_history);
+      }
    }
 
 

--- a/inc/inventorycomputerlib.class.php
+++ b/inc/inventorycomputerlib.class.php
@@ -2103,7 +2103,6 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
       $data['itemtype']             = 'Computer';
       $data['items_id']             = $computers_id;
 
-
       $type_id = $fwTypes->getID();
       $bios_id = $deviceBios->import($data);
 
@@ -2114,7 +2113,7 @@ class PluginFusioninventoryInventoryComputerLib extends PluginFusioninventoryInv
             $item_DeviceBios->fields['devicefirmwares_id']   = $bios_id;
             $item_DeviceBios->fields['devicefirmwaretypes_id'] = $type_id;
             $item_DeviceBios->fields['is_dynamic']           = 1;
-            $item_DeviceBios->update($item_DeviceBios->fields,$no_history);
+            $item_DeviceBios->update($item_DeviceBios->fields, $no_history);
          }
       } else {
          $data['_no_history']          = $no_history;


### PR DESCRIPTION
Currently the FI plugin always adds a component of firmware type without checking if the component already exists.

This PR prevent this behavior.

First step : check if a bios already exist for item (Computer / NetworkEquipment / Printer)
Second: add or update link between computer and bios if needed (update only if DB and XML are different for bios information)

