### PR TITLE
Fix rules

### DIFF
--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -545,7 +545,7 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
       }
 
       // Build the request to check if the machine exists in GLPI
-      $where_entity = "";
+      $where_entity = "";//FIXME: not used
       if (isset($input['entities_id'])) {
          if (is_array($input['entities_id'])) {
             $where_entity .= implode(',', $input['entities_id']);

--- a/inc/inventoryruleimport.class.php
+++ b/inc/inventoryruleimport.class.php
@@ -527,14 +527,7 @@ class PluginFusioninventoryInventoryRuleImport extends Rule {
          foreach ($global_criteria as $criterion) {
             $criteria = $this->getCriteriaByID($criterion);
             foreach ($criteria as $crit) {
-               if ($crit->fields["condition"] !== Rule::PATTERN_EXISTS
-                     && $crit->fields["condition"] !== Rule::PATTERN_DOES_NOT_EXISTS
-                     && $crit->fields["condition"] !== PluginFusioninventoryInventoryRuleImport::PATTERN_ENTITY_RESTRICT
-                     && $crit->fields["condition"] !== PluginFusioninventoryInventoryRuleImport::PATTERN_NETWORK_PORT_RESTRICT
-                     && $crit->fields["condition"] !== PluginFusioninventoryInventoryRuleImport::PATTERN_ONLY_CRITERIA_RULE) {
-
-                     $complex_criterias_strings[] = $crit->fields["criteria"];
-               }
+               $complex_criterias_strings[] = $crit->fields["criteria"];
             }
          }
          foreach ($input as $key=>$crit) {


### PR DESCRIPTION
Not a bug in 9.4, but spotted on 9.5.

The `if` was comparing `fields['condition']` which is a string with `Rule` class constants which are integers, using a strict comparison; so whatever was the value in the field, values were defferent and we enter in the `if`.

If we try to cast the field as an integer (glpi 9.5 now uses real datatype from db), many tests begin to fail (several on network part); so I've concluded this code part has never worked and should be dropped.

Also, the other commit point a non used part of SQL condition I do not know exactly what to do with (ping @ddurieux ?).