### PR TITLE
Do not override GLPI error handler

### DIFF
--- a/front/communication.php
+++ b/front/communication.php
@@ -64,7 +64,6 @@ if (!isset($_SESSION['glpilanguage'])) {
 $_SESSION['glpi_fusionionventory_nolock'] = true;
 ini_set('display_errors', 'On');
 error_reporting(E_ALL | E_STRICT);
-set_error_handler(['Toolbox', 'userErrorHandlerDebug']);
 $_SESSION['glpi_use_mode'] = 0;
 $_SESSION['glpiparententities'] = '';
 $_SESSION['glpishowallentities'] = true;


### PR DESCRIPTION
`Toolbox::userErrorHandlerDebug()` has been deprecated in GLPI 9.5 in favor of a new error handler that handles both DEBUG and NORMAL mode.

This new handler is already defined by `includes` scripts.