### PR TITLE
Fix WakeUpAgent cron

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1042,7 +1042,7 @@ class PluginFusioninventoryAgent extends CommonDBTM {
             array_push($url_addresses, "http://".$computer->fields["name"].
                ":".$port);
 
-            $ditem = new DomainItem();
+            $ditem = new Domain_Item();
             if ($ditem->getFromDBByCrit(['itemtype' => 'Computer', 'items_id' => $computer->fields['id']])) {
                $domain = new Domain();
                $domain->getFromDB($ditem->fields['domains_id']);


### PR DESCRIPTION
Fix following error: 
```
[2020-07-09 11:19:39] glpiphplog.CRITICAL: *** Uncaught Exception Error: Class 'DomainItem' not found in /var/www/html/glpi/plugins/fusioninventory/inc/agent.class.php at line 1045
Backtrace :
plugins/fusioninventory/inc/agent.class.php:1084 PluginFusioninventoryAgent->getAgentBaseURLs()
plugins/fusioninventory/inc/agent.class.php:885 PluginFusioninventoryAgent->getAgentStatusURLs()
...s/fusioninventory/inc/agentwakeup.class.php:188 PluginFusioninventoryAgent->getStatus()
inc/crontask.class.php:847 PluginFusioninventoryAgentWakeup::cronWakeupAgents()
front/crontask.form.php:49 CronTask::launch()
```