### PR TITLE
feat(core): Export IP Range conf to yaml file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
     "prefer-stable": true,
     "require-dev": {
         "glpi-project/tools": "^0.1.0"
+    },
+    "require": {
+        "symfony/yaml": "4.0.0"
     }
 }

--- a/front/export.php
+++ b/front/export.php
@@ -1,9 +1,8 @@
 <?php
-
 /**
  * FusionInventory
  *
- * Copyright (C) 2010-2016 by the FusionInventory Development Team.
+ * Copyright (C) 2010-2020 by the FusionInventory Development Team.
  *
  * http://www.fusioninventory.org/
  * https://github.com/fusioninventory/fusioninventory-for-glpi
@@ -30,13 +29,13 @@
  *
  * ------------------------------------------------------------------------
  *
- * This file is used to manage the IP range search list.
+ * This file is used to manage the redirection to the documentation page.
  *
  * ------------------------------------------------------------------------
  *
  * @package   FusionInventory
- * @author    David Durieux
- * @copyright Copyright (c) 2010-2016 FusionInventory team
+ * @author    Stanislas Kita
+ * @copyright Copyright (c) 2010-2020 FusionInventory team
  * @license   AGPL License 3.0 or (at your option) any later version
  *            http://www.gnu.org/licenses/agpl-3.0-standalone.html
  * @link      http://www.fusioninventory.org/
@@ -46,15 +45,19 @@
 
 include ("../../../inc/includes.php");
 
-Html::header(__('FusionInventory', 'fusioninventory'), $_SERVER["PHP_SELF"], "admin",
-             "pluginfusioninventorymenu", "iprange");
-
 Session::checkRight('plugin_fusioninventory_iprange', READ);
 
-PluginFusioninventoryMenu::displayMenu("mini");
-PluginFusioninventoryIPRange::titleList();
+$ID = null;
+if (isset($_GET['id'])) {
+   $ID = $_GET['id'];
+}
 
-Search::show('PluginFusioninventoryIPRange');
-
-Html::footer();
+if (PluginFusioninventoryIPRange::exportAsYaml($ID)) {
+   $filename = "fusioninventory_ip_conf.yaml";
+   $path = GLPI_TMP_DIR."/fusioninventory_ip_conf.yaml";
+   Toolbox::sendFile($path, $filename);
+} else {
+   Session::addMessageAfterRedirect("No data to export", false, INFO);
+   Html::back();
+}
 


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

Export IP range configuration to YAML file 

ex 

```yaml
credentials:
    'Public community v1-1':
        id: 1
        name: 'Public community v1'
        snmpversion: v1
        community: public
        username: ''
        authentication: MD5
        auth_passphrase: ''
        encryption: AES
        priv_passphrase: ''
    'Public community v2c-2':
        id: 2
        name: 'Public community v2c'
        snmpversion: v2c
        community: public
        username: ''
        authentication: ''
        auth_passphrase: ''
        encryption: ''
        priv_passphrase: ''
ip_range:
    'Caen-1':
        id: 1
        name: 'Caen'
        ip_start: 10.94.0.0
        ip_end: 10.94.0.255
        credentials:
            - 'Public community v1-1'
            - 'Public community v2c-2'
    'Paris-2':
        id: 2
        name: Paris
        ip_start: 10.0.1.0
        ip_end: 10.0.1.255
        credentials:
            - 'Public community v1-1'
            - 'Public community v2c-2'
```


export available for all containers

![image](https://user-images.githubusercontent.com/7335054/72048328-d5c63a80-32bc-11ea-9606-d234d21a9b80.png)


 or just one

![image](https://user-images.githubusercontent.com/7335054/72048308-ca730f00-32bc-11ea-818d-d2f2c104d774.png)


