### PR TITLE
feat(inventory): add hook for networkequipement and printer

### DIFF
--- a/inc/inventorynetworkequipmentlib.class.php
+++ b/inc/inventorynetworkequipmentlib.class.php
@@ -167,6 +167,12 @@ class PluginFusioninventoryInventoryNetworkEquipmentLib extends PluginFusioninve
 
       //Import simcards
       $this->importSimcards('NetworkEquipment', $a_inventory, $items_id, $no_history);
+
+      Plugin::doHook("fusioninventory_inventory",
+      ['inventory_data' => $a_inventory,
+       'networkequipments_id'   => $items_id,
+       'no_history'     => $no_history
+      ]);
    }
 
 

--- a/inc/inventoryprinterlib.class.php
+++ b/inc/inventoryprinterlib.class.php
@@ -164,6 +164,12 @@ class PluginFusioninventoryInventoryPrinterLib extends PluginFusioninventoryInve
       // Cartridges
       $this->importCartridges($a_inventory['cartridge'], $printers_id);
 
+      Plugin::doHook("fusioninventory_inventory",
+      ['inventory_data' => $a_inventory,
+       'printers_id'   => $printers_id,
+       'no_history'     => $no_history
+      ]);
+
    }
 
 


### PR DESCRIPTION
A hook to manage inventory after fusioninventory.

This hook is already present for computer.

This PR add this feature for Networkequipment and Printer inventory.

Best regards