### PR TITLE
Fill domain criterion before applying location rules

### DIFF
--- a/inc/inventorycomputerinventory.class.php
+++ b/inc/inventorycomputerinventory.class.php
@@ -327,7 +327,12 @@ class PluginFusioninventoryInventoryComputerInventory {
 
       //Add the location if needed (play rule locations engine)
       $output = [];
-      $output = PluginFusioninventoryToolbox::addLocation($input, $output);
+      $inputloc = $input;
+      if ((isset($a_computerinventory['Computer']['domains_id']))
+          AND (!empty($a_computerinventory['Computer']['domains_id']))) {
+          $inputloc['domain'] = $a_computerinventory['Computer']['domains_id'];
+      }
+      $output = PluginFusioninventoryToolbox::addLocation($inputloc, $output);
       if (isset($output['locations_id'])) {
          $_SESSION['plugin_fusioninventory_locations_id'] =
                $output['locations_id'];


### PR DESCRIPTION
Close #3151

This change fills the `domain` field of the input data before passing it to the location rule processor. It allows users using the `Domain` criterion in location rules.