### PR TITLE
Fix collect task reporting on not found file collect

### DIFF
--- a/inc/collect.class.php
+++ b/inc/collect.class.php
@@ -797,7 +797,7 @@ class PluginFusioninventoryCollect extends CommonDBTM {
                            'machineid' => $pfAgent->fields['device_id'],
                            'uuid'      => $uuid,
                            'code'      => 'running',
-                           'msg'       => "$name: file ".$a_values['path']." | size ".$a_values['size']
+                           'msg'       => (isset($name) ? "$name: file " : "file ").$a_values['path']." | size ".$a_values['size']
                         ];
                         if (isset($a_values['sendheaders'])) {
                            $params['sendheaders'] = $a_values['sendheaders'];


### PR DESCRIPTION
By now, when a file collect task finds nothing, it just reports the task run "Successful" and there's no way to understand the file search indeed failed.
With this update, the task goes in error when no file is found and we have a better reporting when more than one search file job is defined:
![image](https://user-images.githubusercontent.com/12514489/134902870-d7b14434-6890-4224-90ec-e4790622f6cf.png)

