### PR TITLE
Netdiscovery XML should not be silently ignored when imported manually

### DIFF
--- a/inc/communicationnetworkdiscovery.class.php
+++ b/inc/communicationnetworkdiscovery.class.php
@@ -102,10 +102,11 @@ class PluginFusioninventoryCommunicationNetworkDiscovery {
          }
       }
 
+      $pfImportExport = new PluginFusioninventorySnmpmodelImportExport();
+      $errors .= $pfImportExport->import_netdiscovery($a_CONTENT, $p_DEVICEID);
+
       if ($pfTaskjobstate->getFromDB($a_CONTENT['PROCESSNUMBER'])) {
          if ($pfTaskjobstate->fields['state'] != PluginFusioninventoryTaskjobstate::FINISHED) {
-            $pfImportExport = new PluginFusioninventorySnmpmodelImportExport();
-            $errors .= $pfImportExport->import_netdiscovery($a_CONTENT, $p_DEVICEID);
             if (isset($a_CONTENT['AGENT']['END'])) {
                $messages = [
                    'Total Found' => 0,


### PR DESCRIPTION
I need this feature to test possible issues related to cases like [OIDs for UCS 6300 Series Fabric Interconnect](https://github.com/fusioninventory/fusioninventory-agent/issues/950) as it seems the components support feature is changing the device model but maybe other things.
This would also permit to import netdiscovery XML files generated by fusioninventory-netdiscovery or glpi-netdiscovery using the injector script.