### PR TITLE
correction error JQuery for update graph in task

### DIFF
--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -816,7 +816,7 @@ taskjobs.update_logs = function (data) {
       });
    }
 
-   $(Object.keys(taskjobs.charts)).delay(500).each(function(i,v) {
+   $(Object.keys(taskjobs.charts)).each(function(i,v) {
       taskjobs.update_progressbar(taskjobs.charts[v]);
    });
 


### PR DESCRIPTION
Error : Uncaught TypeError: Object.defineProperty called on non-object


taskjobs.update_logs(data)
taskjobs.js?v=9.5+3.0:819 {job_53_PluginFusioninventoryDeployPackage_48_0: Array(1), job_53_PluginFusioninventoryDeployPackage_49_1: Array(1), job_55_PluginFusioninventoryDeployPackage_50_0: Array(1)}
(anonymous) @ taskjobs.js?v=9.5+3.0:819
(anonymous) @ VM19059:1
taskjobs.js?v=9.5+3.0:820 jQuery.fn.init(3) ["job_53_PluginFusioninventoryDeployPackage_48_0", "job_53_PluginFusioninventoryDeployPackage_49_1", "job_55_PluginFusioninventoryDeployPackage_50_0"]
(anonymous) @ taskjobs.js?v=9.5+3.0:820
(anonymous) @ VM19059:1
base.min.js?v=9.5.6:25 Uncaught TypeError: Object.defineProperty called on non-object
    at Function.defineProperty (<anonymous>)
    at tt.cache (base.min.js?v=9.5.6:25)
    at tt.set (base.min.js?v=9.5.6:25)
    at tt.access (base.min.js?v=9.5.6:25)
    at Function.queue (base.min.js?v=9.5.6:25)
    at String.<anonymous> (base.min.js?v=9.5.6:25)
    at Function.each (base.min.js?v=9.5.6:14)
    at jQuery.fn.init.each (base.min.js?v=9.5.6:14)
    at jQuery.fn.init.queue (base.min.js?v=9.5.6:25)
    at jQuery.fn.init.k.fn.delay (base.min.js?v=9.5.6:25)
cache @ base.min.js?v=9.5.6:25
set @ base.min.js?v=9.5.6:25
access @ base.min.js?v=9.5.6:25
queue @ base.min.js?v=9.5.6:25
(anonymous) @ base.min.js?v=9.5.6:25
each @ base.min.js?v=9.5.6:14
each @ base.min.js?v=9.5.6:14
queue @ base.min.js?v=9.5.6:25
k.fn.delay @ base.min.js?v=9.5.6:25
(anonymous) @ taskjobs.js?v=9.5+3.0:820
(anonymous) @ VM19059:1