### PR TITLE
Fix Notice when inventory rules are empty

### DIFF
--- a/inc/inventoryruleimportcollection.class.php
+++ b/inc/inventoryruleimportcollection.class.php
@@ -184,7 +184,8 @@ class PluginFusioninventoryInventoryRuleImportCollection extends RuleCollection 
    function getRuleClassName() {
 
       if (preg_match('/(.*)Collection/', get_class($this), $rule_class)) {
-         if (debug_backtrace()[1]['function'] == 'getRuleListCriteria') {
+         $debug_backtrace = debug_backtrace();
+         if (is_array($debug_backtrace) && isset($debug_backtrace[1]) && $debug_backtrace[1]['function'] == 'getRuleListCriteria') {
             $rule_class[1] = str_replace('\\', '\\\\\\', $rule_class[1]);
          }
          return $rule_class[1];


### PR DESCRIPTION
Fresh install
Menu Administration > Rules
If rules are empty, 2 notices are displayed :
Notice: Undefined offset: 1 in /glpi/plugins/fusioninventory/inc/inventoryruleimportcollection.class.php on line 187
and 
Notice: Trying to access array offset on value of type null in /glpi/plugins/fusioninventory/inc/inventoryruleimportcollection.class.php on line 187

Add check for debug_backtrace() result is an array with at least key 1.