### PR TITLE
Fix Lint 8.0 errors with spaces at end of line

### DIFF
--- a/inc/agent.class.php
+++ b/inc/agent.class.php
@@ -1227,9 +1227,9 @@ class PluginFusioninventoryAgent extends CommonDBTM {
             'last_contact' => ['<', new QueryExpression("date_add(now(), interval -".$retentiontime." day)")]
          ]
       ]);
-      
+
       $cron_status = false;
-      if (count($iterator)) {   
+      if (count($iterator)) {
          $action = $pfConfig->getValue('agents_action');
          if ($action == PluginFusioninventoryConfig::ACTION_CLEAN) {
             //delete agents
@@ -1257,4 +1257,3 @@ class PluginFusioninventoryAgent extends CommonDBTM {
 
 
 }
-


### PR DESCRIPTION
lines 1230 and 1232 : extra spaces before end of line removed.