### PR TITLE
getTaskjobstatesForAgent  order by list of targets

### DIFF
--- a/inc/task.class.php
+++ b/inc/task.class.php
@@ -279,7 +279,7 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
          "     task.`id`, task.`name`, task.`is_active`,",
          "     task.`datetime_start`, task.`datetime_end`,",
          "     task.`plugin_fusioninventory_timeslots_exec_id` as timeslot_id,",
-         "     job.`id`, job.`name`, job.`method`, job.`actors`,",
+         "     job.`id`, job.`name`, job.`method`, job.`actors`, job.targets,",
          "     run.`itemtype`, run.`items_id`, run.`state`,",
          "     run.`id`, run.`plugin_fusioninventory_agents_id`",
          "FROM `glpi_plugin_fusioninventory_taskjobstates` run",
@@ -306,6 +306,12 @@ class PluginFusioninventoryTask extends PluginFusioninventoryTaskView {
       if ($query_result) {
          $results = PluginFusioninventoryToolbox::fetchAssocByTable($query_result);
       }
+      
+      foreach ($results as &$result) {
+         $targets = importArrayFromDB($result['job']['targets']);
+         $result['order'] = $result['job']['id'] . '-' . array_search( $result['run']['items_id'], array_column($targets, $result['run']['itemtype']));
+      }
+      usort($result, function($a, $b) {return strcmp($a->order, $b->order);});
 
       // Fetch a list of unique actors since the same actor can be assigned to many jobs.
       $actors = [];


### PR DESCRIPTION
the result should be ordered by the future job.index field when drag AND drop feature will be properly activated in the taskjobs list.