### PR TITLE
error "restart selected job" when agent is pinned

### DIFF
--- a/js/taskjobs.js
+++ b/js/taskjobs.js
@@ -189,9 +189,10 @@ function pin_agent(args) {
    //chart.pinned_agents = {};
    chart.pinned_agents[agent_id] = chart.agents.toObject()[agent_id];
    chart.pinned_agents[agent_id].logs = {};
-   taskjobs.refresh_pinned_agents(chart_id);
+   //taskjobs.refresh_pinned_agents(chart_id);
    //agents_dispatch.view(chart_id);
    //   taskjobs.update_agents_view(chart_id);
+   taskjobs.queue_refresh_logs( taskjobs.ajax_url, taskjobs.task_id );
 }
 
 function add_runlogs(extra) {


### PR DESCRIPTION
when an agent is pinned and the list is not refreshed manually or automatically, the values of input check_restart are not updated. this element takes the value of the following element and shifts all values.
There is certainly a more efficient solution than this.